### PR TITLE
Centralize panel geometry computation. Fix warnings.

### DIFF
--- a/src/FigurlCanvas/Geometry.ts
+++ b/src/FigurlCanvas/Geometry.ts
@@ -248,7 +248,7 @@ const zip = (a: any[], b: any[]) => {
 export const transformPoints = (tmatrix: TransformationMatrix, points: Vec2[]): Vec2[] => {
     const A = matrix(tmatrix)
     const x = matrix([points.map((p) => p[0]), points.map((p) => p[1]), points.map((p) => 1)])
-    const [xvalues, yvalues, _] = multiply(A, x).toArray() as number[][]
+    const [xvalues, yvalues] = multiply(A, x).toArray() as number[][]
     // assert xvalues.length = yvalues.length
     return zip(xvalues, yvalues)
 }

--- a/src/views/RasterPlot/TimeScrollView/paint.ts
+++ b/src/views/RasterPlot/TimeScrollView/paint.ts
@@ -2,7 +2,7 @@ import { TSVAxesLayerProps } from "./TSVAxesLayer"
 import { MainLayerProps } from "./TSVMainLayer"
 
 export const paintPanels = <T extends {[key: string]: any}>(context: CanvasRenderingContext2D, props: MainLayerProps<T>) => {
-    const {width, height, margins, panels, perPanelOffset } = props
+    const {margins, panels, perPanelOffset } = props
     context.resetTransform()
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
     context.translate(margins.left, margins.top)
@@ -18,7 +18,7 @@ const highlightedRowFillStyle = '#c5e1ff' // TODO: This should be standardized a
 export const paintAxes = <T extends {[key: string]: any}>(context: CanvasRenderingContext2D, props: TSVAxesLayerProps<T> & {'selectedPanelKeys': string[]}) => {
     // I've left the timeRange in the props list since we will probably want to display something with it at some point
     // Q: maybe it'd be better to look at context.canvas.width rather than the width prop?
-    const {width, height, margins, timeRange, panels, panelHeight, perPanelOffset, selectedPanelKeys} = props
+    const {width, height, margins, panels, panelHeight, perPanelOffset, selectedPanelKeys} = props
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
     
     // x-axes


### PR DESCRIPTION
This is mostly just centralizing the geometry computations as we talked about yesterday & doing some housekeeping to remove unused-variable messages.