### PR TITLE
Use hook for time tick computation

### DIFF
--- a/src/views/RasterPlot/TimeScrollView/TSVAxesLayer.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TSVAxesLayer.tsx
@@ -1,11 +1,12 @@
 import BaseCanvas from 'FigurlCanvas/BaseCanvas';
 import React, { useMemo } from 'react';
 import { paintAxes } from './paint';
-import { TimeScrollViewPanel } from './TimeScrollView';
+import { TimeScrollViewPanel, TimeTick } from './TimeScrollView';
 
 export type TSVAxesLayerProps<T extends {[key: string]: any}> = {
     panels: TimeScrollViewPanel<T>[]
     timeRange: [number, number]
+    timeTicks: TimeTick[]
     focusTimePixels?: number
     margins: {left: number, right: number, top: number, bottom: number}
     selectedPanelKeys: string[]
@@ -16,10 +17,10 @@ export type TSVAxesLayerProps<T extends {[key: string]: any}> = {
 }
 
 const TSVAxesLayer = <T extends {[key: string]: any}>(props: TSVAxesLayerProps<T>) => {
-    const {width, height, panels, panelHeight, perPanelOffset, timeRange, focusTimePixels, margins, selectedPanelKeys} = props
+    const {width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, focusTimePixels, margins, selectedPanelKeys} = props
     const drawData = useMemo(() => ({
-        width, height, panels, panelHeight, perPanelOffset, timeRange, focusTimePixels, margins, selectedPanelKeys,
-    }), [width, height, panels, panelHeight, perPanelOffset, timeRange, focusTimePixels, margins, selectedPanelKeys])
+        width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, focusTimePixels, margins, selectedPanelKeys,
+    }), [width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, focusTimePixels, margins, selectedPanelKeys])
 
     return (
         <BaseCanvas

--- a/src/views/RasterPlot/TimeScrollView/paint.ts
+++ b/src/views/RasterPlot/TimeScrollView/paint.ts
@@ -18,7 +18,7 @@ const highlightedRowFillStyle = '#c5e1ff' // TODO: This should be standardized a
 export const paintAxes = <T extends {[key: string]: any}>(context: CanvasRenderingContext2D, props: TSVAxesLayerProps<T> & {'selectedPanelKeys': string[]}) => {
     // I've left the timeRange in the props list since we will probably want to display something with it at some point
     // Q: maybe it'd be better to look at context.canvas.width rather than the width prop?
-    const {width, height, margins, panels, panelHeight, focusTimePixels, perPanelOffset, selectedPanelKeys, timeRange, timeTicks} = props
+    const {width, height, margins, panels, panelHeight, focusTimePixels, perPanelOffset, selectedPanelKeys, timeTicks} = props
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
     
     // x-axes

--- a/src/views/RasterPlot/TimeScrollView/paint.ts
+++ b/src/views/RasterPlot/TimeScrollView/paint.ts
@@ -15,113 +15,10 @@ export const paintPanels = <T extends {[key: string]: any}>(context: CanvasRende
 
 const highlightedRowFillStyle = '#c5e1ff' // TODO: This should be standardized across the application
 
-type TimeTick = {
-    value: number
-    label: string
-    major: boolean
-}
-
-const getTimeTicks = (timeRange: [number, number], width: number) => {
-    const tickUnits: {
-        name: string,
-        duration: number
-        num: number,
-        label: (a: number) => string
-    }[] = [
-        {
-            name: '1ms',
-            duration: 0.001,
-            num: 10,
-            label: (a: number) => (`${a % 1000} ms`)
-        },
-        {
-            name: '10ms',
-            duration: 0.01,
-            num: 10,
-            label: (a: number) => (`${(a * 10) % 1000} ms`)
-        },
-        {
-            name: '100ms',
-            duration: 0.1,
-            num: 10,
-            label: (a: number) => (`${(a * 100) % 1000} ms`)
-        },
-        {
-            name: '1s',
-            duration: 1,
-            num: 10,
-            label: (a: number) => (`${a % 60} s`)
-        },
-        {
-            name: '10s',
-            duration: 10,
-            num: 6,
-            label: (a: number) => (`${(a * 10) % 60} s`)
-        },
-        {
-            name: '1min',
-            duration: 60,
-            num: 10,
-            label: (a: number) => (`${a % 60} min`)
-        },
-        {
-            name: '10min',
-            duration: 60 * 10,
-            num: 6,
-            label: (a: number) => (`${(a * 10) % 60} min`)
-        },
-        {
-            name: '1hr',
-            duration: 60 * 60,
-            num: 6,
-            label: (a: number) => (`${a % 24} hr`)
-        },
-        {
-            name: '6hr',
-            duration: 60 * 60 * 6,
-            num: 4,
-            label: (a: number) => (`${(a * 6) % 24} hr`)
-        },
-        {
-            name: '1day',
-            duration: 60 * 60 * 24,
-            num: 10,
-            label: (a: number) => (`${a} day`)
-        },
-        {
-            name: '10day',
-            duration: 60 * 60 * 24 * 10,
-            num: 10000,
-            label: (a: number) => (`${10 * a} day`)
-        }
-    ]
-    const ret: TimeTick[] = []
-    for (let u of tickUnits) {
-        const i1 = Math.ceil(timeRange[0] / u.duration)
-        const i2 = Math.floor(timeRange[1] / u.duration) 
-        const n = i2 - i1 + 1
-        const pixelsPerTick = width / n
-        if (pixelsPerTick > 50) {
-            const major = (pixelsPerTick > 200) || (n <= 5)
-            for (let i = i1; i <= i2; i++) {
-                const v = i % u.num
-                if (v !== 0) {
-                    ret.push({
-                        value: i * u.duration,
-                        label: u.label(i),
-                        major
-                    })
-                }
-            }
-        }
-    }
-    return ret
-}
-
 export const paintAxes = <T extends {[key: string]: any}>(context: CanvasRenderingContext2D, props: TSVAxesLayerProps<T> & {'selectedPanelKeys': string[]}) => {
     // I've left the timeRange in the props list since we will probably want to display something with it at some point
     // Q: maybe it'd be better to look at context.canvas.width rather than the width prop?
-    const {width, height, margins, panels, panelHeight, focusTimePixels, perPanelOffset, selectedPanelKeys, timeRange} = props
+    const {width, height, margins, panels, panelHeight, focusTimePixels, perPanelOffset, selectedPanelKeys, timeRange, timeTicks} = props
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
     
     // x-axes
@@ -129,17 +26,16 @@ export const paintAxes = <T extends {[key: string]: any}>(context: CanvasRenderi
     drawLine(context, margins.left, height - margins.bottom, width - margins.right, height - margins.bottom)
 
     // time ticks
-    const timeTicks = getTimeTicks(timeRange, width - margins.left - margins.right)
     for (let tt of timeTicks) {
-        const frac = (tt.value - timeRange[0]) / (timeRange[1] - timeRange[0])
-        const x = margins.left + frac * (width - margins.left - margins.right)
+        // const frac = (tt.value - timeRange[0]) / (timeRange[1] - timeRange[0])
+        // const x = margins.left + frac * (width - margins.left - margins.right)
         context.strokeStyle = tt.major ? 'gray' : 'lightgray'
-        drawLine(context, x, height - margins.bottom, x, margins.top)
+        drawLine(context, tt.pixelXposition, height - margins.bottom, tt.pixelXposition, margins.top)
         context.textAlign = 'center'
         context.textBaseline = 'top'
         const y1 = height - margins.bottom + 5
         context.fillStyle = tt.major ? 'black' : 'gray'
-        context.fillText(tt.label, x, y1)
+        context.fillText(tt.label, tt.pixelXposition, y1)
     }
 
     // selected panels


### PR DESCRIPTION
This moves the time tick computation into a memoized hook in `TimeScrollView.tsx` and renames some of the variables. It also uses vectorized pixel placement computation at the time the ticks are computed, to avoid doing it in the paint function (even though that's probably not a big driver of anything under present expectations).

To account for the margins, I added an optional (defaults to 0) extra pixel offset for the 1d time to pixel matrix computations; this fixed a bug I introduced while playing with this.