### PR TITLE
Implement electrode geometry widget & bugfixes.

### DIFF
--- a/src/views/AverageWaveforms/AverageWaveformPlot.tsx
+++ b/src/views/AverageWaveforms/AverageWaveformPlot.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent, useMemo } from 'react';
-import WaveformWidget from './WaveformWidget/WaveformWidget'
+import WaveformWidget from './WaveformWidget/WaveformWidget';
 
 type Props = {
     channelIds: number[]
@@ -25,7 +25,6 @@ const AverageWaveformPlot: FunctionComponent<Props> = ({channelIds, waveform, wa
         }))
     }, [channelIds, channelLocations])
     const waveformOpts = useMemo(() => ({waveformWidth: 1}), [])
-    const selectedElectrodeIds = useMemo(() => ([]), [])
     return (
         <WaveformWidget
             waveform={waveform}
@@ -35,7 +34,6 @@ const AverageWaveformPlot: FunctionComponent<Props> = ({channelIds, waveform, wa
             layoutMode={channelLocations ? layoutMode : 'vertical'}
             width={width}
             height={height}
-            selectedElectrodeIds={selectedElectrodeIds}
             showLabels={true} // for now
             noiseLevel={noiseLevel}
             samplingFrequency={samplingFrequency}

--- a/src/views/AverageWaveforms/AverageWaveformsView.tsx
+++ b/src/views/AverageWaveforms/AverageWaveformsView.tsx
@@ -25,6 +25,8 @@ const AverageWaveformsView: FunctionComponent<Props> = ({data, width, height}) =
         setSelectedUnitIds(keys.map(k => (Number(k))))
     }, [setSelectedUnitIds])
 
+    // NEED INITIALIZATION CALL HERE BUT WE DON'T ACTUALLY HAVE A FULL LIST OF KNOWN ELECTRODES
+
     const [ampScaleFactor, setAmpScaleFactor] = useState<number>(1)
     const [waveformsMode, setWaveformsMode] = useState<string>('geom')
 

--- a/src/views/AverageWaveforms/AverageWaveformsView.tsx
+++ b/src/views/AverageWaveforms/AverageWaveformsView.tsx
@@ -25,8 +25,6 @@ const AverageWaveformsView: FunctionComponent<Props> = ({data, width, height}) =
         setSelectedUnitIds(keys.map(k => (Number(k))))
     }, [setSelectedUnitIds])
 
-    // NEED INITIALIZATION CALL HERE BUT WE DON'T ACTUALLY HAVE A FULL LIST OF KNOWN ELECTRODES
-
     const [ampScaleFactor, setAmpScaleFactor] = useState<number>(1)
     const [waveformsMode, setWaveformsMode] = useState<string>('geom')
 

--- a/src/views/AverageWaveforms/WaveformWidget/WaveformWidget.tsx
+++ b/src/views/AverageWaveforms/WaveformWidget/WaveformWidget.tsx
@@ -1,6 +1,5 @@
-import { Electrode } from 'contexts/RecordingSelectionContext'
 import { FunctionComponent, useMemo } from 'react'
-import ElectrodeGeometry, { defaultMaxPixelRadius, LayoutMode } from './sharedDrawnComponents/ElectrodeGeometry'
+import ElectrodeGeometry, { defaultMaxPixelRadius, Electrode, LayoutMode } from './sharedDrawnComponents/ElectrodeGeometry'
 import { computeElectrodeLocations, xMargin as xMarginDefault } from './sharedDrawnComponents/electrodeGeometryLayout'
 import { ElectrodeColors } from './sharedDrawnComponents/electrodeGeometryPainting'
 import { getSpikeAmplitudeNormalizationFactor } from './waveformLogic'

--- a/src/views/AverageWaveforms/WaveformWidget/WaveformWidget.tsx
+++ b/src/views/AverageWaveforms/WaveformWidget/WaveformWidget.tsx
@@ -1,5 +1,6 @@
+import { Electrode } from 'contexts/RecordingSelectionContext'
 import { FunctionComponent, useMemo } from 'react'
-import ElectrodeGeometry, { defaultMaxPixelRadius, Electrode, LayoutMode } from './sharedDrawnComponents/ElectrodeGeometry'
+import ElectrodeGeometry, { defaultMaxPixelRadius, LayoutMode } from './sharedDrawnComponents/ElectrodeGeometry'
 import { computeElectrodeLocations, xMargin as xMarginDefault } from './sharedDrawnComponents/electrodeGeometryLayout'
 import { ElectrodeColors } from './sharedDrawnComponents/electrodeGeometryPainting'
 import { getSpikeAmplitudeNormalizationFactor } from './waveformLogic'
@@ -14,8 +15,6 @@ export type WaveformWidgetProps = {
     layoutMode: LayoutMode
     width: number
     height: number
-    selectedElectrodeIds: number[]
-    // selectionDispatch: RecordingSelectionDispatch
     colors?: ElectrodeColors
     showLabels?: boolean
     noiseLevel: number
@@ -35,7 +34,7 @@ const electrodeColors: ElectrodeColors = {
     dragged: 'rgb(0, 0, 196)',
     draggedSelected: 'rgb(180, 180, 150)',
     dragRect: 'rgba(196, 196, 196, 0.5)',
-    textLight: 'rgb(32, 92, 92)',
+    textLight: 'rgb(162, 162, 162)',
     textDark: 'rgb(32, 150, 150)'
 }
 const waveformColors: WaveformColors = {
@@ -58,21 +57,19 @@ const WaveformWidget: FunctionComponent<WaveformWidgetProps> = (props) => {
     const showLabels = props.showLabels ?? defaultElectrodeOpts.showLabels
     const colors = props.colors ?? defaultElectrodeOpts.colors
     const waveformOpts = useMemo(() => ({...defaultWaveformOpts, ...props.waveformOpts}), [props.waveformOpts])
-    const {electrodes, selectedElectrodeIds, waveform, waveformStdDev, ampScaleFactor: userSpecifiedAmplitudeScaling, layoutMode, width, height} = props
+    const {electrodes, waveform, waveformStdDev, ampScaleFactor: userSpecifiedAmplitudeScaling, layoutMode, width, height} = props
 
     const geometry = useMemo(() => <ElectrodeGeometry
         electrodes={electrodes}
-        selectedElectrodeIds={selectedElectrodeIds}
-        // selectionDispatch={selectionDispatch}
         width={width}
         height={height}
         layoutMode={layoutMode}
         colors={colors}
         showLabels={showLabels}      // Would we ever not want to show labels for this?
-        offsetLabels={true}
+        // offsetLabels={true}  // this isn't appropriate for a waveform view--it mislabels the electrodes
         maxElectrodePixelRadius={defaultMaxPixelRadius}
         disableSelection={true}      // ??
-    />, [electrodes, selectedElectrodeIds, width, height, layoutMode, colors, showLabels])
+    />, [electrodes, width, height, layoutMode, colors, showLabels])
 
     // TODO: Don't do this twice, work it out differently
     const { convertedElectrodes, pixelRadius, xMargin: xMarginBase } = computeElectrodeLocations(width, height, electrodes, layoutMode, defaultMaxPixelRadius)

--- a/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/ElectrodeGeometry.tsx
+++ b/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/ElectrodeGeometry.tsx
@@ -1,4 +1,4 @@
-import { Electrode, useSelectedElectrodes } from 'contexts/RecordingSelectionContext'
+import { useSelectedElectrodes } from 'contexts/RecordingSelectionContext'
 import BaseCanvas from 'FigurlCanvas/BaseCanvas'
 import DragCanvas, { DragAction, handleMouseDownIfDragging, handleMouseMoveIfDragging, handleMouseUpIfDragging } from 'FigurlCanvas/DragCanvas'
 import { Vec2 } from 'FigurlCanvas/Geometry'
@@ -10,6 +10,13 @@ import SvgElectrodeLayout from './ElectrodeGeometrySvg'
 const USE_SVG = false
 
 export const defaultMaxPixelRadius = 25
+
+export type Electrode = {
+    id: number
+    label: string
+    x: number
+    y: number
+}
 
 export type PixelSpaceElectrode = {
     e: Electrode

--- a/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/ElectrodeGeometry.tsx
+++ b/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/ElectrodeGeometry.tsx
@@ -1,3 +1,4 @@
+import { Electrode, useSelectedElectrodes } from 'contexts/RecordingSelectionContext'
 import BaseCanvas from 'FigurlCanvas/BaseCanvas'
 import DragCanvas, { DragAction, handleMouseDownIfDragging, handleMouseMoveIfDragging, handleMouseUpIfDragging } from 'FigurlCanvas/DragCanvas'
 import { Vec2 } from 'FigurlCanvas/Geometry'
@@ -10,26 +11,16 @@ const USE_SVG = false
 
 export const defaultMaxPixelRadius = 25
 
-export type Electrode = {
-    id: number
-    label: string
-    x: number
-    y: number
-}
-
 export type PixelSpaceElectrode = {
     e: Electrode
     pixelX: number
     pixelY: number
-    // transform: TransformationMatrix // Dunno if we really need this?
 }
 
 export type LayoutMode = 'geom' | 'vertical'
 
 interface WidgetProps {
     electrodes: Electrode[],
-    selectedElectrodeIds: number[]
-    // selectionDispatch: RecordingSelectionDispatch
     width: number
     height: number
     colors?: ElectrodeColors
@@ -53,20 +44,21 @@ const getEventPoint = (e: React.MouseEvent) => {
 }
 
 const ElectrodeGeometry = (props: WidgetProps) => {
-    const { width, height, electrodes, selectedElectrodeIds } = props
+    const { width, height, electrodes } = props
+    const { selectedElectrodeIds, setSelectedElectrodeIds } = useSelectedElectrodes()
     const disableSelection = props.disableSelection ?? false
     const offsetLabels = props.offsetLabels ?? false
     const colors = props.colors ?? defaultColors
     const layoutMode: LayoutMode = props.layoutMode ?? 'geom'
     const maxElectrodePixelRadius = props.maxElectrodePixelRadius || defaultElectrodeLayerProps.maxElectrodePixelRadius
     const [state, dispatchState] = useReducer(electrodeGeometryReducer, {
-            convertedElectrodes: [],
-            pixelRadius: -1,
-            draggedElectrodeIds: [],
-            pendingSelectedElectrodeIds: selectedElectrodeIds,
-            dragState: {isActive: false},
-            xMarginWidth: -1
-        })
+                                                convertedElectrodes: [],
+                                                pixelRadius: -1,
+                                                draggedElectrodeIds: [],
+                                                pendingSelectedElectrodeIds: selectedElectrodeIds,
+                                                dragState: {isActive: false},
+                                                xMarginWidth: -1
+                                            })
 
     useEffect(() => {
         const type: ElectrodeGeometryActionType = 'INITIALIZE'
@@ -81,11 +73,12 @@ const ElectrodeGeometry = (props: WidgetProps) => {
         dispatchState(a)
     }, [width, height, electrodes, layoutMode, maxElectrodePixelRadius])
 
-    // // Call to update selected electrode IDs if our opinion differs from the one that was passed in
-    // // (but only if our opinion has changed)
-    // useEffect(() => {
-    //     selectionDispatch({type: 'SetSelectedElectrodeIds', selectedElectrodeIds: state.pendingSelectedElectrodeIds})
-    // }, [selectionDispatch, state.pendingSelectedElectrodeIds])
+    // Call to update selected electrode IDs if our opinion differs from the one that was passed in
+    // (but only if our opinion has changed)
+    // TODO: Does this create a race condition??
+    useEffect(() => {
+        setSelectedElectrodeIds(state.pendingSelectedElectrodeIds)
+    }, [setSelectedElectrodeIds, state.pendingSelectedElectrodeIds])
 
     const nextDragStateUpdate = useRef<DragAction | null>(null)
     const nextFrame = useRef<number>(0)

--- a/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryLayout.ts
+++ b/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryLayout.ts
@@ -171,7 +171,7 @@ const computeDataToPixelTransform = (width: number, height: number, scaleFactor:
 const normalizeElectrodeLocations = (width: number, height: number, electrodes: Electrode[]): Electrode[] => {
     const canvasAspectRatio = (width - xMargin * 2) / (height - yMargin * 2)
     const _electrodes = replaceEmptyLocationsWithDefaultLayout(electrodes)
-    const {boxAspect: boxAspectRatio, boxCenter} = getElectrodesAspectRatio(_electrodes)
+    const {boxAspect: boxAspectRatio} = getElectrodesAspectRatio(_electrodes)
     if (boxAspectRatio === 1 || canvasAspectRatio === 1 || (boxAspectRatio > 1) === (canvasAspectRatio > 1)) {
         // Aspect ratios (W/H) < 1 are portrait mode. > 1 are landscape.
         // If either source or target is a square, or if the canvas & native-space aspect ratios match,

--- a/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryLayout.ts
+++ b/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryLayout.ts
@@ -1,12 +1,34 @@
-import { Electrode } from 'contexts/RecordingSelectionContext'
 import funcToTransform from "FigurlCanvas/funcToTransform"
-import { getBoundingBoxForEllipse, getHeight, getWidth, RectangularRegion, TransformationMatrix, transformPoints, Vec2 } from "FigurlCanvas/Geometry"
+import { getHeight, getWidth, RectangularRegion, TransformationMatrix, transformPoints, Vec2 } from "FigurlCanvas/Geometry"
 import { min, norm } from "mathjs"
-import { defaultMaxPixelRadius, PixelSpaceElectrode } from './ElectrodeGeometry'
+import { defaultMaxPixelRadius, Electrode, PixelSpaceElectrode } from './ElectrodeGeometry'
 import { getArrayMax, getArrayMin } from "./utility"
 
 export const xMargin = 10
 const yMargin = 10
+
+export const computeElectrodesFromIdsAndLocations = (ids: number[], channelLocations?: {[key: string]: number[]}): Electrode[] => {
+    const locs = channelLocations || {}
+    if (channelLocations &&
+        (Object.keys(locs).length !== ids.length
+         || ids.some(id => !locs[`${id}`])
+    )) {
+        console.warn(`Attempt to compute electrode locations with mismatched lists. Skipping...`)
+        return []
+    }
+
+    const electrodes = ids.map(id => {
+        const locationForElectrode = locs[`${id}`] || [id, 0]
+        return {
+            id,
+            label: `${id}`,
+            x: locationForElectrode[0],
+            y: locationForElectrode[1]
+        }
+    })
+
+    return electrodes
+}
 
 const computeRadiusCache = new Map<string, number>()
 const computeRadiusDataSpace = (electrodes: Electrode[]): number => {
@@ -26,7 +48,7 @@ const computeRadiusDataSpace = (electrodes: Electrode[]): number => {
             leastNorm = Math.min(leastNorm, dist as number)
         })
     })
-    // (might set a hard cap, but remember these numbers are in electrode-space coordinates)
+    // (could set a hard cap, but remember these numbers are in electrode-space coordinates)
     const radius = 0.45 * leastNorm
     computeRadiusCache.set(key, radius)
     return radius
@@ -44,8 +66,11 @@ const getElectrodeSetBoundingBox = (electrodes: Electrode[], radius: number): Re
 const getElectrodesAspectRatio = (electrodes: Electrode[]) => {
     const radius = computeRadiusDataSpace(electrodes)
     const boundingBox = getElectrodeSetBoundingBox(electrodes, radius)
-    const boxAspect = getWidth(boundingBox) / getHeight(boundingBox)
-    return boxAspect
+    const boxWidth = getWidth(boundingBox)
+    const boxHeight = getHeight(boundingBox)
+    const boxCenter = { x: (boxWidth/2) + boundingBox.xmin, y: (boxHeight/2) + boundingBox.ymin}
+    const boxAspect = boxWidth / boxHeight
+    return {boxAspect, boxCenter}
 }
 
 const replaceEmptyLocationsWithDefaultLayout = (electrodes: Electrode[]): Electrode[] => {
@@ -73,35 +98,20 @@ const computeDataToPixelTransformVerticalLayout = (width: number, height: number
     })
 }
 
-// NOTE TO SELF: for vertical layout, radius is 1/(n+1) in dataspace.
+// NOTE: for vertical layout, radius is 1/(n+1) in dataspace.
 // pixelradius is thus (canvas height less vertical margins) / n+1 (where n = # of electrodes).
-
 const convertElectrodesToPixelSpaceVerticalLayout = (electrodes: Electrode[], transform: TransformationMatrix): PixelSpaceElectrode[] => {
     // for vertical layout, we ignore any actual location information and just distribute the electrodes evenly over a column.
     // Do that here by resetting the processed electrode geometry into the assigned points.
     const points = electrodes.map((e, ii) => [0.5, (0.5 + ii)/(1 + electrodes.length)])
     const pixelspacePoints = transformPoints(transform, points)
 
-    // pixelRadius is only used to compute the 'transform' value, which we may not even use...
     return electrodes.map((e, ii) =>  {
         const [pixelX, pixelY] = pixelspacePoints[ii]
-        const electrodeBoundingBox: RectangularRegion = {
-            xmin: 0,
-            xmax: 1,
-            ymin: (ii / electrodes.length),
-            ymax: ((ii + 1)/electrodes.length)
-        }
         return {
             e: e,
             pixelX: pixelX,
             pixelY: pixelY,
-            // This is the transform *from the unit square* to the electrode bounding box's pixelspace directly
-            // If you want to project anything into that space you need to normalize to the unit square first.
-            transform: funcToTransform((p: Vec2): Vec2 => {
-                const a = electrodeBoundingBox.xmin + p[0] * (electrodeBoundingBox.xmax - electrodeBoundingBox.xmin)
-                const b = electrodeBoundingBox.ymin + p[1] * (electrodeBoundingBox.ymax - electrodeBoundingBox.ymin)
-                return [a, b]
-            })
         }
     })
 }
@@ -134,52 +144,55 @@ const computeDataToPixelTransform = (width: number, height: number, scaleFactor:
     // Since we computed scale using a default margin, the final margin will never be less than the default.
     const electrodeBoxWidth = getWidth(electrodeLayoutBoundingBox)
     const xMarginFinal = (width - electrodeBoxWidth * scaleFactor) / 2
-    // const electrodeBoxHeight = getHeight(electrodeLayoutBoundingBox)
-    // const yMarginFinal = (height - electrodeBoxHeight * scaleFactor) / 2
 
     // Note the need to invert the y-axis here.
     // We want to map -s * ymin -> h - ymargin, and -s * ymax -> ymargin. This will put the scaled minimum
-    // observed value at "pixel drawing margin" away from the figure bottom, and the scaled maximum observed
-    // value at "pixel drawing margin" away from the figure top.
+    // data value at {pixel drawing margin} away from the figure bottom, and the scaled maximum data
+    // value at {pixel drawing margin} away from the figure top.
     // So we need to scale by -scaleFactor and offset by some value Q, where:
-    // -s * ymin + Q = h - ymargin
-    // -s * ymax + Q = ymargin
+    //    -s * ymin + Q = h - ymargin
+    //    -s * ymax + Q = ymargin
     // Sum those:
-    // -s*ymin + -s*ymax + 2Q = h - ymargin + ymargin --> -s (ymin + ymax) + 2Q = h -->
-    // 2Q = h + s (ymin + ymax)
-    // So Q is half the height, plus the scaled sum of the extreme range values in the input data.
-    // It's tricky because when ymin = -ymax, that term cancels and it *looks* like we just need
-    // to offset by half the drawing space height, but this is not the case.
-    // Also nice to note this holds for any choice of y-margin.
-    // Also note, in the case where s = h/(max-min), this works out to s*max, which is what appears
-    // in the TimeScrollView. (That doesn't hold here because s might be based on the x-scale.)
+    //    -s*ymin + -s*ymax + 2Q = h - ymargin + ymargin --> -s (ymin + ymax) + 2Q = h -->
+    //           2Q = h + s (ymin + ymax)
+    // So Q is half of (the height, plus the scaled sum of the extreme range values in the input data).
+    // Observations:
+    //  - This holds for any choice of y-margin, since that term cancels.
+    //  - When the data extremes are symmetric around the x-axis -- i.e. ymin = -ymax -- that term cancels &
+    //    it *looks* like we can just offset by half the drawing-space height. But this doesn't work for the general case.
+    //  - In TimeScrollView, we used an offset Q = s * ymax -- this formula reduces to that one for the special case
+    //    where s = h / (ymax - ymin), but that doesn't hold here since the scale factor s might be set by
+    //    the drawing-space width or the maximum pixel radius.
     const xrow = [ scaleFactor, 0, xMarginFinal - electrodeLayoutBoundingBox.xmin * scaleFactor ]
-    const yrow = [0, -scaleFactor, (height + scaleFactor * (electrodeLayoutBoundingBox.xmin + electrodeLayoutBoundingBox.xmax)) / 2 ]
+    const yrow = [0, -scaleFactor, (height + scaleFactor * (electrodeLayoutBoundingBox.ymin + electrodeLayoutBoundingBox.ymax)) / 2 ]
     return [xrow, yrow, [0, 0, 1]]
-
-    // This transform doesn't invert the y-axis
-    // return funcToTransform((p: Vec2): Vec2 => {
-    //     const x = xMarginFinal + (p[0] - electrodeLayoutBoundingBox.xmin) * scaleFactor
-    //     const y = yMarginFinal + (p[1] - electrodeLayoutBoundingBox.ymin) * scaleFactor
-    //     // const y = (2 * yMarginFinal + electrodeBoxHeight) - ((p[1] - electrodeLayoutBoundingBox.ymax) * scaleFactor)
-    //     return [x, y]
-    // })
 }
 
 const normalizeElectrodeLocations = (width: number, height: number, electrodes: Electrode[]): Electrode[] => {
     const canvasAspectRatio = (width - xMargin * 2) / (height - yMargin * 2)
     const _electrodes = replaceEmptyLocationsWithDefaultLayout(electrodes)
-    const boxAspectRatio = getElectrodesAspectRatio(_electrodes)
-    if ((boxAspectRatio >= 1) === (canvasAspectRatio >= 1)) {
-        // Aspect ratios > 1 are portrait mode. < 1 are landscape. We want to check that the orientations match.
-        // If they do, just return the input.
-        // (use >= because we don't want to rotate if they're both squares--err on the side of not rotating.)
+    const {boxAspect: boxAspectRatio, boxCenter} = getElectrodesAspectRatio(_electrodes)
+    if (boxAspectRatio === 1 || canvasAspectRatio === 1 || (boxAspectRatio > 1) === (canvasAspectRatio > 1)) {
+        // Aspect ratios (W/H) < 1 are portrait mode. > 1 are landscape.
+        // If either source or target is a square, or if the canvas & native-space aspect ratios match,
+        // then we don't need to do anything.
         return electrodes
     }
-    // If the orientations don't match, we'll rotate the electrode set 90 degrees CW around the origin.
-    // (This is accomplished by making new-x = old-y and new-y = negative old-x.)
-    // Subsequent functions will then pick up the new bounding box correctly.
-    return electrodes.map((e) => {return {...e, x: e.y, y: -e.x }})
+    // If the orientations don't match, we'll rotate the electrode set 90 degrees around the origin, which
+    // is accomplished by setting new-x = old-y and new-y = negative old-x.
+    return electrodes.map((e) => ({...e, x: e.y, y: -e.x}))
+
+    // We could also rotate around the center of the bounding box. We dono't actually need to, since the
+    // conversion to pixelspace is indifferent to translations of the source data set.
+    // But just in case it comes up in the future, here's how you would do that:
+    //   1) Get a new location relative to the set center (by subtracting the original point from the center point)
+    //   2) In those coordinates, rotate by setting new-x = old-y and new-y = negative old-x; and
+    //   3) Recenter by adding in again the center point.
+    // return electrodes.map((e) => {
+    //     const relativeX = e.x - boxCenter.x
+    //     const relativeY = e.y - boxCenter.y
+    //     return {...e, x: relativeY + boxCenter.x, y: -relativeX + boxCenter.y }
+    // })
 }
 
 const convertElectrodesToPixelSpace = (electrodes: Electrode[], transform: TransformationMatrix, pixelRadius: number): PixelSpaceElectrode[] => {
@@ -188,16 +201,12 @@ const convertElectrodesToPixelSpace = (electrodes: Electrode[], transform: Trans
     // pixelRadius is only used to compute the 'transform' value, which we may not even use...
     return electrodes.map((e, ii) =>  {
         const [pixelX, pixelY] = pixelspacePoints[ii]
-        const electrodeBoundingBox = getBoundingBoxForEllipse([pixelX, pixelY], pixelRadius, pixelRadius)
+        // Again, per-electrode transform isn't actually needed for anything
+        // const electrodeBoundingBox = getBoundingBoxForEllipse([pixelX, pixelY], pixelRadius, pixelRadius)
         return {
             e: e,
             pixelX: pixelX,
             pixelY: pixelY,
-            transform: funcToTransform((p: Vec2): Vec2 => {
-                const a = electrodeBoundingBox.xmin + p[0] * (electrodeBoundingBox.xmax - electrodeBoundingBox.xmin)
-                const b = electrodeBoundingBox.ymin + p[1] * (electrodeBoundingBox.ymax - electrodeBoundingBox.ymin)
-                return [a, b]
-            })
         }
     })
 }
@@ -236,7 +245,6 @@ export const computeElectrodeLocations = (canvasWidth: number, canvasHeight: num
             pixelRadius: pixelRadius
         }
     }
-
     const normalizedElectrodes = normalizeElectrodeLocations(canvasWidth, canvasHeight, electrodes)
     const nativeRadius = computeRadiusDataSpace(normalizedElectrodes)
 
@@ -246,6 +254,7 @@ export const computeElectrodeLocations = (canvasWidth: number, canvasHeight: num
     const transform = computeDataToPixelTransform(canvasWidth, canvasHeight, scaleFactor, nativeBoundingBox)
     const xMarginFinal = (canvasWidth - getWidth(nativeBoundingBox) * scaleFactor) / 2
     const convertedElectrodes = convertElectrodesToPixelSpace(normalizedElectrodes, transform, pixelRadius)
+
     return {
         transform: transform,
         convertedElectrodes: convertedElectrodes,

--- a/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryStateManagement.tsx
+++ b/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryStateManagement.tsx
@@ -1,7 +1,6 @@
-import { Electrode } from 'contexts/RecordingSelectionContext'
 import { DragAction, dragReducer, DragState } from 'FigurlCanvas/DragCanvas'
 import { pointSpanToRegion, Vec2 } from "FigurlCanvas/Geometry"
-import { LayoutMode, PixelSpaceElectrode } from './ElectrodeGeometry'
+import { Electrode, LayoutMode, PixelSpaceElectrode } from './ElectrodeGeometry'
 import { computeElectrodeLocations, getDraggedElectrodeIds, getElectrodeAtPoint, xMargin as xMarginDefault } from './electrodeGeometryLayout'
 
 export interface ElectrodeGeometryState {
@@ -111,7 +110,7 @@ export const electrodeGeometryReducer = (state: ElectrodeGeometryState, action: 
         const clickedId = getElectrodeAtPoint(state.convertedElectrodes, state.pixelRadius, action.point)
         // Suppose we clicked nothing. If no modifier was down & there's a selection to clear, clear it;
         // otherwise nothing actually happens so return the existing state.
-        if (clickedId === 0 || clickedId === undefined) {
+        if (clickedId === undefined) {
             return (!(action.shift || action.ctrl) && action.selectedElectrodeIds.length > 0) 
             ?   {
                     ...state,

--- a/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryStateManagement.tsx
+++ b/src/views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryStateManagement.tsx
@@ -1,6 +1,7 @@
+import { Electrode } from 'contexts/RecordingSelectionContext'
 import { DragAction, dragReducer, DragState } from 'FigurlCanvas/DragCanvas'
 import { pointSpanToRegion, Vec2 } from "FigurlCanvas/Geometry"
-import { Electrode, LayoutMode, PixelSpaceElectrode } from './ElectrodeGeometry'
+import { LayoutMode, PixelSpaceElectrode } from './ElectrodeGeometry'
 import { computeElectrodeLocations, getDraggedElectrodeIds, getElectrodeAtPoint, xMargin as xMarginDefault } from './electrodeGeometryLayout'
 
 export interface ElectrodeGeometryState {

--- a/src/views/ElectrodeGeometry/ElectrodeGeometryView.tsx
+++ b/src/views/ElectrodeGeometry/ElectrodeGeometryView.tsx
@@ -1,6 +1,6 @@
-import { useElectrodeSet, useRecordingSelectionElectrodeInitialization } from 'contexts/RecordingSelectionContext'
 import React, { FunctionComponent } from 'react'
 import ElectrodeGeometry from 'views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/ElectrodeGeometry'
+import { computeElectrodesFromIdsAndLocations } from 'views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/electrodeGeometryLayout'
 import { ElectrodeGeometryViewData } from './ElectrodeGeometryViewData'
 
 type ElectrodeGeometryViewProps = {
@@ -12,12 +12,7 @@ type ElectrodeGeometryViewProps = {
 const ElectrodeGeometryView: FunctionComponent<ElectrodeGeometryViewProps> = (props: ElectrodeGeometryViewProps) => {
     const { data, width, height } = props
     const channelIds = Object.keys(data.channelLocations).map(id => parseInt(id))
-
-    useRecordingSelectionElectrodeInitialization(channelIds, data.channelLocations)
-    const { electrodes } = useElectrodeSet()
-
-    // TODO: Have the underlying component pull the electrode list from context
-    // and have the parent pass in only a list of the visible electrodes to filter
+    const electrodes = computeElectrodesFromIdsAndLocations(channelIds, data.channelLocations)
 
     return (
         <ElectrodeGeometry

--- a/src/views/ElectrodeGeometry/ElectrodeGeometryView.tsx
+++ b/src/views/ElectrodeGeometry/ElectrodeGeometryView.tsx
@@ -1,20 +1,30 @@
+import { useElectrodeSet, useRecordingSelectionElectrodeInitialization } from 'contexts/RecordingSelectionContext'
 import React, { FunctionComponent } from 'react'
+import ElectrodeGeometry from 'views/AverageWaveforms/WaveformWidget/sharedDrawnComponents/ElectrodeGeometry'
 import { ElectrodeGeometryViewData } from './ElectrodeGeometryViewData'
 
-type Props = {
+type ElectrodeGeometryViewProps = {
     data: ElectrodeGeometryViewData
     width: number
     height: number
 }
 
-const ElectrodeGeometryView: FunctionComponent<Props> = ({data, width, height}) => {
+const ElectrodeGeometryView: FunctionComponent<ElectrodeGeometryViewProps> = (props: ElectrodeGeometryViewProps) => {
+    const { data, width, height } = props
+    const channelIds = Object.keys(data.channelLocations).map(id => parseInt(id))
+
+    useRecordingSelectionElectrodeInitialization(channelIds, data.channelLocations)
+    const { electrodes } = useElectrodeSet()
+
+    // TODO: Have the underlying component pull the electrode list from context
+    // and have the parent pass in only a list of the visible electrodes to filter
+
     return (
-        <div>
-            <p>Not yet implemented</p>
-            <div>
-                <pre>{JSON.stringify(data, null, 4)}</pre>
-            </div>
-        </div>
+        <ElectrodeGeometry
+            width={width}
+            height={height}
+            electrodes={electrodes}
+        />
     )
 }
 

--- a/src/views/RasterPlot/RasterPlotView.tsx
+++ b/src/views/RasterPlot/RasterPlotView.tsx
@@ -1,4 +1,4 @@
-import { useRecordingSelectionInitialization, useTimeRange } from 'contexts/RecordingSelectionContext'
+import { useRecordingSelectionTimeInitialization, useTimeRange } from 'contexts/RecordingSelectionContext'
 import { useSelectedUnitIds } from 'contexts/SortingSelectionContext'
 import { matrix, multiply } from 'mathjs'
 import React, { FunctionComponent, useCallback, useMemo } from 'react'
@@ -33,7 +33,7 @@ const RasterPlotView: FunctionComponent<Props> = ({data, width, height}) => {
         setSelectedUnitIds(keys.map(k => (Number(k))))
     }, [setSelectedUnitIds])
 
-    useRecordingSelectionInitialization(data.startTimeSec, data.endTimeSec)
+    useRecordingSelectionTimeInitialization(data.startTimeSec, data.endTimeSec)
     const { visibleTimeStartSeconds, visibleTimeEndSeconds } = useTimeRange()
 
     // Compute the per-panel pixel drawing area dimensions.

--- a/src/views/RasterPlot/TimeScrollView/TimeScrollView.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TimeScrollView.tsx
@@ -118,16 +118,19 @@ export const use2dPanelDataToPixelMatrix = (pixelsPerSecond: number, startTimeSe
         //
         // which gives us an input, a scale, and an offset.
         // For the inverted case, rewrite [2] as:
-        //      [2']  y --> (1 - ((y * userScaleFactor)/y_range) + (y_min/y_range)) * panelHeight
+        //      [2']  y --> (1                 - ((y * userScaleFactor)/y_range) + (y_min/y_range)) * panelHeight
+        // Distribute the panelHeight:
+        //      [2"]  y --> (panelHeight      - (panelHeight * y * usf)/y_range) + (panelHeight * y_min)/y_range)
         // Again, use yScale = (panelHeight) / y_range:
-        //      [2"] y --> (yScale * y_range) - (yScale * y * userScaleFactor) + (yScale * y_min)
+        //      [2"'] y --> (yScale * y_range) - (yScale  * y * userScaleFactor) + (yScale * y_min)
         // and as a scale and offset version:
         //
         //      [2f]  y --> (-yScale * y * userScaleFactor) + (yScale * (y_range + y_min))
+        // (and observe that since y_range = y_max - y_min, then y_range + y_min = y_max.)
 
         const yRange = (dataMax - dataMin)
         const yScale = (panelHeight) / (yRange)
-        const yOffset = invertY ?  yScale * (dataMin + yRange)
+        const yOffset = invertY ?  yScale * dataMax
                                 : -yScale * dataMin
         const finalYScale = userScaleFactor * (invertY ? -yScale : yScale)
         

--- a/src/views/SpikeAmplitudes/SpikeAmplitudesView.tsx
+++ b/src/views/SpikeAmplitudes/SpikeAmplitudesView.tsx
@@ -1,4 +1,4 @@
-import { useRecordingSelectionInitialization, useTimeRange } from 'contexts/RecordingSelectionContext'
+import { useRecordingSelectionTimeInitialization, useTimeRange } from 'contexts/RecordingSelectionContext'
 import { useSelectedUnitIds } from 'contexts/SortingSelectionContext'
 import { matrix, multiply } from 'mathjs'
 import Splitter from 'MountainWorkspace/components/Splitter/Splitter'
@@ -112,7 +112,7 @@ const paintPanel = (context: CanvasRenderingContext2D, props: PanelProps) => {
 }
 
 const SpikeAmplitudesViewChild: FunctionComponent<ChildProps> = ({data, selectedUnitIds, width, height}) => {
-    useRecordingSelectionInitialization(data.startTimeSec, data.endTimeSec)
+    useRecordingSelectionTimeInitialization(data.startTimeSec, data.endTimeSec)
     const {visibleTimeStartSeconds, visibleTimeEndSeconds} = useTimeRange()
     const [ampScaleFactor, setAmpScaleFactor] = useState<number>(1)
 


### PR DESCRIPTION
This PR implements the Electrode Geometry visualizer, along with electrode selection functionality (drag-select, shift-click, ctrl-click, etc.) Selected unit ID is synced between Average Waveforms view and Electrode Geometry view.

PR also fixes a couple display bugs which weren't apparent before, mainly related to layout orientation--we had been flipping the Y axis relative to the probe geometry.

Note: we probably ought to move the electrode geometry stuff out of the average waveform folder, but that isn't done in this PR.