### PR TITLE
Addresses SortingView issues 168, 169.

### DIFF
--- a/src/View.tsx
+++ b/src/View.tsx
@@ -3,17 +3,17 @@ import AutocorrelogramsView from 'views/Autocorrelograms/AutocorrelogramsView';
 import AverageWaveformsView from 'views/AverageWaveforms/AverageWaveformsView';
 import CompositeView from 'views/Composite/CompositeView';
 import ElectrodeGeometryView from 'views/ElectrodeGeometry/ElectrodeGeometryView';
+import EpochsView from 'views/Epochs/EpochsView';
 import LiveCrossCorrelogramsView from 'views/LiveCrossCorrelograms/LiveCrossCorrelogramsView';
+import LivePositionPdfPlotView from 'views/LivePositionPdfPlot/LivePositionPdfPlotView';
 import MountainLayoutView from 'views/MountainLayout/MountainLayoutView';
-import PositionPlotView from 'views/PositionPlot/PositionPlotView';
 import PositionPdfPlotView from 'views/PositionPdfPlot/PositionPdfPlotView';
+import PositionPlotView from 'views/PositionPlot/PositionPlotView';
 import RasterPlotView from 'views/RasterPlot/RasterPlotView';
 import SpikeAmplitudesView from 'views/SpikeAmplitudes/SpikeAmplitudesView';
 import SummaryView from 'views/Summary/SummaryView';
-import UnitsTableView from 'views/UnitsTable/UnitsTableView'
+import UnitsTableView from 'views/UnitsTable/UnitsTableView';
 import { ViewData } from './ViewData';
-import LivePositionPdfPlotView from 'views/LivePositionPdfPlot/LivePositionPdfPlotView';
-import EpochsView from 'views/Epochs/EpochsView';
 
 type Props = {
     data: ViewData
@@ -49,7 +49,7 @@ const View: FunctionComponent<Props> = ({data, width, height}) => {
     else if (data.type === 'ElectrodeGeometry') {
         return <ElectrodeGeometryView data={data} width={width} height={height} />
     }
-    else if (data.type === 'PositionPlot') {
+    else if (data.type === 'PositionPlot' || data.type === 'PositionPlotScatter') {
         return <PositionPlotView data={data} width={width} height={height} />
     }
     else if (data.type === 'LiveCrossCorrelograms') {

--- a/src/views/PositionPlot/PositionPlotViewData.ts
+++ b/src/views/PositionPlot/PositionPlotViewData.ts
@@ -2,7 +2,7 @@ import { validateObject } from "figurl"
 import { isArrayOf, isEqualTo, isString } from "figurl/viewInterface/validateObject"
 
 export type PositionPlotViewData = {
-    type: 'PositionPlot'
+    type: 'PositionPlot' | 'PositionPlotScatter'
     timestamps: number[]
     positions: number[][]
     dimensionLabels: string[]

--- a/src/views/RasterPlot/TimeScrollView/TimeScrollView.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TimeScrollView.tsx
@@ -145,6 +145,12 @@ export const use2dPanelDataToPixelMatrix = (pixelsPerSecond: number, startTimeSe
     }, [pixelsPerSecond, startTimeSec, dataMin, dataMax, userScaleFactor, panelHeight, invertY])
 }
 
+export const getYAxisPixelZero = (TransformMatrix2d: Matrix) => {
+    const augmentedZero = matrix([[0], [0], [1]])
+    const value = (multiply(TransformMatrix2d, augmentedZero).valueOf() as number[][])[1][0]
+    return value
+}
+
 /* Time-axis Tick computations */
 
 export type TimeTick = {


### PR DESCRIPTION
This PR includes several things, some of which are necessary and some of which might be more controversial.

It's intended to address SortingView issues [168](https://github.com/magland/sortingview/issues/168) (support markers vs connecting points for linearized position plot) and [169](https://github.com/magland/sortingview/issues/169) (lines cutting out when the observation value is the same for many observations), which request changes to the Linear Position plots (where the functional component is the [PositionPlotView.tsx](https://github.com/magland/spikesortingview/blob/2eeb6e6ff8102077fda4edb74841e2296015c689/src/views/PositionPlot/PositionPlotView.tsx)).

Fixed line mode:
![image](https://user-images.githubusercontent.com/2347301/150172171-33d6a4c2-71dc-4d94-adb3-0d21abddd094.png)

Scatterplot:
![image](https://user-images.githubusercontent.com/2347301/150172270-af8bcabf-e3a7-4adf-927c-8e7974aeb0b6.png)

(Note the scatterplot reveals discontinuities in the data.)


Key changes:

- Scatterplot vs Linear mode is governed by the data type, which is used by `View.tsx` to choose which component will be used to display the data. I added `PositionPlotScatter` as a permitted data type that will map to this component. It would also have been possible to implement this by adding an additional value to the `data` field passed in--we might yet choose to implement it that way (it was how I'd originally done it) but I was hoping to limit the number of places where we mix actual data and metadata that is actually display logic.
- In `PositionPlotView`, I've added scatterplot support to the `paintPanel` function.
- Additionally, tried setting line width for line mode to 1.1, which eliminated the 'vanishing line' issue (169).
- Not a key change, but a probably useful one--I also added a `getYAxisPixelZero` function to `TimeScrollView.tsx` that, given a transformation matrix, identifies the baseline of a plot. We seem to do this a lot, so might as well functionalize it.

Other changes:
These are code rewrites that were not directly required by the changes that directly solve the issues--we might choose to back them out. But I think they improve clarity and efficiency & make the code more idiomatic.

- In the scatterplot painting function, I iterate using a `forEach` over `props.dimensions` and then another over the `pixelTimes`/`pixelValues`; I also rewrote the line function to use this style instead of explicit `for` loops.
- In building the data series, I reworked the time filtering to filter times outside of the per-dimension loop & take the indices represented by the filtered times.
- In converting data to pixelspace for drawing on the panels, I switched to using the vectorized/matrix-based data point conversion using `use2dPanelDataToPixelMatrix` from `TimeScrollView` rather than the explicit function version. This ought to be more efficient (because of the vectorization), but it could be made even more so in two ways. First, I'm doing one matrix multiplication per dimension, rather than packing all the dimensions, multiplying, and unpacking. (This is probably not a big loss if we only have two or three dimensions.) Second, given that each of the dimensions shares the same time values, we could avoid converting the times repeatedly. However, this would require an additional 1d conversion matrix function in `TimeScrollView` in addition to the time-conversion function and time-and-data conversion function, which I didn't bother with.

To actually see the scatter plot in practice, we'll probably need to redo the FigURL so that it takes advantage of scatterplot mode where appropriate. But for review purposes, you can just uncomment the line (l. 149 in `PositionPlotView`) that manually makes everything a scatterplot.