### PR TITLE
Fixes #29. Implements relative heights in MultiTimeseriesView.

### DIFF
--- a/src/views/MultiTimeseries/MultiTimeseriesView.tsx
+++ b/src/views/MultiTimeseries/MultiTimeseriesView.tsx
@@ -16,7 +16,9 @@ const MultiTimeseriesView: FunctionComponent<Props> = ({data, width, height}) =>
         overflowY: 'auto'
     }), [width, height])
 
-    const H = height / data.panels.length
+    const total_height_allocated = data.panels.reduce((total, panel) => total + (panel?.relativeHeight ?? 1), 0)
+    const unit_height = Math.floor(height / total_height_allocated)
+    console.log(`Allocating net ${total_height_allocated} panelheight with base unit height ${unit_height}`)
 
     return (
         <div style={divStyle}>
@@ -28,7 +30,7 @@ const MultiTimeseriesView: FunctionComponent<Props> = ({data, width, height}) =>
                             figureDataSha1={panel.figureDataSha1}
                             isBottomPanel={ii === (data.panels.length - 1)}
                             width={width}
-                            height={H}
+                            height={Math.floor(unit_height * (panel?.relativeHeight ?? 1))}
                         />
                     </div>
                 ))

--- a/src/views/MultiTimeseries/MultiTimeseriesView.tsx
+++ b/src/views/MultiTimeseries/MultiTimeseriesView.tsx
@@ -18,7 +18,6 @@ const MultiTimeseriesView: FunctionComponent<Props> = ({data, width, height}) =>
 
     const total_height_allocated = data.panels.reduce((total, panel) => total + (panel?.relativeHeight ?? 1), 0)
     const unit_height = Math.floor(height / total_height_allocated)
-    console.log(`Allocating net ${total_height_allocated} panelheight with base unit height ${unit_height}`)
 
     return (
         <div style={divStyle}>


### PR DESCRIPTION
Added relative heights for panels in multi-panel-view display.
Examples:
(1) https://www.figurl.org/f?v=gs://figurl/spikesortingview-1-dev&d=601993ad3b8bc6975b8eb7c98c1c242d0276b453&channel=flatiron1&label=Jaq_03_12_visualization_data
(2) https://www.figurl.org/f?v=gs://figurl/spikesortingview-1&d=964498c2fa87ebd882cf4aa8db7e36486fbc491d&channel=flatiron1&label=Jaq_03_12_visualization_data

Example (1) has been used previously to demonstrate the MultiTimeseriesView. No relative heights are set for any panels in this example. Comparing the code in the present PR with the live version of this FigURL suggests there are no regressions--the code as implemented still works like currently if there are no relative heights specified (since every panel defaults to a relative height of 1).

Example (2) shows relative heights being honored. This example gives a relative height of 4 to the 'Spikes' plot, 2 to the 'Linear Position' plot, none defined to the 'Speed' plot, and 3 to the 'Position Probability' plot. This results in the overall space being split into 10 equal slices, allocated as 4 to the first panel, 2 to the second panel, 1 to the third panel, and 3 to the fourth panel (as requested). Panel heights add up to slightly less than the overall space, because I implemented a `floor()` operation to avoid rounding-error push-up; this probably doesn't matter either way.

Example 2, before this change:
![image](https://user-images.githubusercontent.com/2347301/152571783-a8335c73-1908-4d30-b3be-160448a8a7d1.png)

Example 2, after this change:
![image](https://user-images.githubusercontent.com/2347301/152571724-6929917b-c84f-4e56-b29c-7c4a74a97f27.png)


Note, example (2) from `sortingview-dev` repo's `/examples/multipanel_example_2.py`, which is part of PR #1 for https://github.com/scratchrealm/sortingview-dev/pull/1.