### PR TITLE
Add time-span highlight support. Demo with RasterPlotView.

### DIFF
--- a/src/views/RasterPlot/RasterPlotView.tsx
+++ b/src/views/RasterPlot/RasterPlotView.tsx
@@ -7,7 +7,7 @@ import colorForUnitId from 'views/common/colorForUnitId'
 import { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries'
 import { useTimeseriesMargins } from 'views/PositionPlot/PositionPlotView'
 import { RasterPlotViewData } from './RasterPlotViewData'
-import TimeScrollView, { use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond } from './TimeScrollView/TimeScrollView'
+import TimeScrollView, { filterAndProjectHighlightSpans, use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond, useTimespanToPixelMatrix } from './TimeScrollView/TimeScrollView'
 
 type Props = {
     data: RasterPlotViewData
@@ -76,6 +76,10 @@ const RasterPlotView: FunctionComponent<Props> = ({data, timeseriesLayoutOpts, w
         }
     })), [data.plots, visibleTimeStartSeconds, visibleTimeEndSeconds, timeToPixelMatrix, paintPanel])
 
+    const spanTransform = useTimespanToPixelMatrix(timeToPixelMatrix)
+    const highlightSpans = data.highlightIntervals ? filterAndProjectHighlightSpans(data.highlightIntervals, visibleTimeStartSeconds, visibleTimeEndSeconds, spanTransform)
+                                                   : []
+
     return visibleTimeStartSeconds === undefined
     ? (<div>Loading...</div>)
     : (
@@ -85,6 +89,7 @@ const RasterPlotView: FunctionComponent<Props> = ({data, timeseriesLayoutOpts, w
             panelSpacing={panelSpacing}
             selectedPanelKeys={selectedPanelKeys}
             setSelectedPanelKeys={setSelectedPanelKeys}
+            highlightSpans={highlightSpans}
             timeseriesLayoutOpts={timeseriesLayoutOpts}
             width={width}
             height={height}

--- a/src/views/RasterPlot/RasterPlotViewData.ts
+++ b/src/views/RasterPlot/RasterPlotViewData.ts
@@ -1,5 +1,6 @@
 import { validateObject } from "figurl"
-import { isArrayOf, isEqualTo, isNumber } from "figurl/viewInterface/validateObject"
+import { isArrayOf, isEqualTo, isNumber, optional } from "figurl/viewInterface/validateObject"
+import { HighlightIntervalSet, isHighlightIntervalSet } from './TimeScrollView/TimeScrollViewData'
 
 type RPPlotData = {
     unitId: number
@@ -18,6 +19,7 @@ export type RasterPlotViewData = {
     startTimeSec: number
     endTimeSec: number
     plots: RPPlotData[]
+    highlightIntervals?: HighlightIntervalSet[]
 }
 
 export const isRasterPlotViewData = (x: any): x is RasterPlotViewData => {
@@ -25,6 +27,7 @@ export const isRasterPlotViewData = (x: any): x is RasterPlotViewData => {
         type: isEqualTo('RasterPlot'),
         startTimeSec: isNumber,
         endTimeSec: isNumber,
-        plots: isArrayOf(isRPPlotData)
+        plots: isArrayOf(isRPPlotData),
+        highlightIntervals: optional(isArrayOf(isHighlightIntervalSet))
     })
 }

--- a/src/views/RasterPlot/TimeScrollView/TSVCursorLayer.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TSVCursorLayer.tsx
@@ -1,16 +1,18 @@
 import BaseCanvas from 'FigurlCanvas/BaseCanvas';
 import React, { useMemo } from 'react';
+import { PixelHighlightSpanSet } from './TimeScrollView';
 
 export type TSVCursorLayerProps = {
     timeRange: [number, number]
     focusTimePixels?: number
+    highlightSpans?: PixelHighlightSpanSet[]
     margins: {left: number, right: number, top: number, bottom: number}
     width: number
     height: number
 }
 
 const paintCursor = (context: CanvasRenderingContext2D, props: TSVCursorLayerProps) => {
-    const {margins, focusTimePixels} = props
+    const {margins, focusTimePixels, highlightSpans} = props
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
 
     // focus time
@@ -21,13 +23,39 @@ const paintCursor = (context: CanvasRenderingContext2D, props: TSVCursorLayerPro
         context.lineTo(focusTimePixels, context.canvas.height - margins.bottom)
         context.stroke()
     }
+
+    if (highlightSpans && highlightSpans.length > 0) {
+        paintSpanHighlights(context, margins.top, context.canvas.height - margins.bottom, highlightSpans)
+    }
 }
 
+// const defaultSpanHighlightColor = "rgba(161, 87, 201, 0.5)" // a nice light purple. or try rgba(117, 56, 150, 0.5)
+// some nice purples: [161, 87, 201], or darker: [117, 56, 150]
+// dark blue: 0, 30, 255
+const defaultSpanHighlightColor = [0, 30, 255]
+
+const paintSpanHighlights = (context: CanvasRenderingContext2D, zeroHeight: number, visibleHeight: number, highlightSets: PixelHighlightSpanSet[]) => {
+    highlightSets.forEach(h => {
+        const definedColor = h.color || defaultSpanHighlightColor
+        const [r, g, b, a] = [...definedColor]
+        if (a) context.fillStyle = `rgba(${r}, ${g}, ${b}, ${a})`
+
+        h.pixelSpans.forEach((span) => {
+            if (!a) {
+                const alpha = span.width < 2 ? 1 : 0.5
+                context.fillStyle = `rgba(${r}, ${g}, ${b}, ${alpha})`
+            }
+            context.fillRect(span.start, zeroHeight, span.width, visibleHeight)
+        })
+    })
+}
+
+
 const TSVCursorLayer = (props: TSVCursorLayerProps) => {
-    const {width, height, timeRange, focusTimePixels, margins} = props
+    const {width, height, timeRange, focusTimePixels, margins, highlightSpans} = props
     const drawData = useMemo(() => ({
-        width, height, timeRange, focusTimePixels, margins,
-    }), [width, height, timeRange, focusTimePixels, margins])
+        width, height, timeRange, focusTimePixels, margins, highlightSpans
+    }), [width, height, timeRange, focusTimePixels, margins, highlightSpans])
 
     return (
         <BaseCanvas

--- a/src/views/RasterPlot/TimeScrollView/TSVCursorLayer.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TSVCursorLayer.tsx
@@ -29,7 +29,6 @@ const paintCursor = (context: CanvasRenderingContext2D, props: TSVCursorLayerPro
     }
 }
 
-// const defaultSpanHighlightColor = "rgba(161, 87, 201, 0.5)" // a nice light purple. or try rgba(117, 56, 150, 0.5)
 // some nice purples: [161, 87, 201], or darker: [117, 56, 150]
 // dark blue: 0, 30, 255
 const defaultSpanHighlightColor = [0, 30, 255]

--- a/src/views/RasterPlot/TimeScrollView/TimeScrollViewData.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TimeScrollViewData.tsx
@@ -1,0 +1,26 @@
+import { validateObject } from "figurl"
+import { isArrayOf, isNumber, optional } from "figurl/viewInterface/validateObject"
+
+export type HighlightIntervalSet = {
+    intervalStarts: number[]
+    intervalEnds: number[]
+    color?: number[] // optional to set the span highlight color for each set of spans.
+    // color, if defined, should be an array of 3 or 4 numbers representing the [r, g, b, a]
+    // components of the chosen color in the range 0-255.
+    // If a is set, a constant alpha will be used throughout, but it's recommended to leave it
+    // blank, in which case we will automatically use full alpha for sub-two-pixel span widths
+    // and downgrade to 50% alpha for spans of 2 or more pixels, which helps make the spans
+    // visible at smaller zooms but not opaque at higher zooms.
+}
+
+export const isHighlightIntervalSet = (x: any): x is HighlightIntervalSet => {
+    const baseCheck = validateObject(x, {
+        intervalStarts: isArrayOf(isNumber),
+        intervalEnds: isArrayOf(isNumber),
+        color: optional(isArrayOf(isNumber))
+    })
+    const lengthCheck = x.intervalStarts.length === x.intervalEnds.length
+    const orderCheck = x.intervalStarts.every((startVal: number, index: number) => startVal <= x.intervalEnds[index])
+    const validColorCheck = (!x.color) || (x.color.length > 2 && x.color.length < 5)
+    return baseCheck && lengthCheck && orderCheck && validColorCheck
+}


### PR DESCRIPTION
Addresses SortingView issue #182 (https://github.com/magland/sortingview/issues/182)

This PR adds functionality to handle spans of intervals that are to be highlighted in the data. As detailed in comments to the above issue, these spans are expected to be defined as a list of start times and end times connected by index, so that each span begins at `spans[0][n]` and ends at `spans[1][n]`. Arbitrarily many span-sets can be supported for any data source, and span highlight color can be left as default or set to a different color per set of spans.

One feature to call out here: if the user specifies a particular alpha, that'll be used throughout; otherwise I set the alpha to 0.5 (half-transparent) for spans that are wider than 2 pixels, and 1 (full visible) for spans smaller than that. I found that otherwise it was either too hard to see small highlight regions, or things were too opaque when zooming in.

Spans do need to be added to each time series separately. It might be possible to add an overall set of spans to a composite view, but this would require some more complex contextual logic & would come at the expense of supporting spans in individual components.

Logic to handle spans, along with defining their data types, has been incorporated as part of the `TimeSeriesView` component. It would otherwise need to be repeated across each component type, and I'd rather define it centrally.

If we like this, it can be added to any other `TimeScrollView`-based component with just a couple lines to update the data type and pass the values in.

Demo: https://www.figurl.org/f?v=http://localhost:3000/&d=3efdf652e24633ba8345fb6a02af9d01fc67e5d1&channel=flatiron1&label=SPANS_TEST

![image](https://user-images.githubusercontent.com/2347301/155415664-aff7707d-755b-49e2-834a-9f0827dad1c1.png)
