### PR TITLE
Fix bugs in interval display.

### DIFF
--- a/src/views/RasterPlot/RasterPlotView.tsx
+++ b/src/views/RasterPlot/RasterPlotView.tsx
@@ -7,7 +7,7 @@ import colorForUnitId from 'views/common/colorForUnitId'
 import { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries'
 import { useTimeseriesMargins } from 'views/PositionPlot/PositionPlotView'
 import { RasterPlotViewData } from './RasterPlotViewData'
-import TimeScrollView, { filterAndProjectHighlightSpans, use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond, useTimespanToPixelMatrix } from './TimeScrollView/TimeScrollView'
+import TimeScrollView, { use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond } from './TimeScrollView/TimeScrollView'
 
 type Props = {
     data: RasterPlotViewData
@@ -76,10 +76,6 @@ const RasterPlotView: FunctionComponent<Props> = ({data, timeseriesLayoutOpts, w
         }
     })), [data.plots, visibleTimeStartSeconds, visibleTimeEndSeconds, timeToPixelMatrix, paintPanel])
 
-    const spanTransform = useTimespanToPixelMatrix(timeToPixelMatrix)
-    const highlightSpans = data.highlightIntervals ? filterAndProjectHighlightSpans(data.highlightIntervals, visibleTimeStartSeconds, visibleTimeEndSeconds, spanTransform)
-                                                   : []
-
     return visibleTimeStartSeconds === undefined
     ? (<div>Loading...</div>)
     : (
@@ -89,7 +85,7 @@ const RasterPlotView: FunctionComponent<Props> = ({data, timeseriesLayoutOpts, w
             panelSpacing={panelSpacing}
             selectedPanelKeys={selectedPanelKeys}
             setSelectedPanelKeys={setSelectedPanelKeys}
-            highlightSpans={highlightSpans}
+            highlightSpans={data.highlightIntervals}
             timeseriesLayoutOpts={timeseriesLayoutOpts}
             width={width}
             height={height}

--- a/src/views/RasterPlot/TimeScrollView/TSVCursorLayer.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TSVCursorLayer.tsx
@@ -25,7 +25,7 @@ const paintCursor = (context: CanvasRenderingContext2D, props: TSVCursorLayerPro
     }
 
     if (highlightSpans && highlightSpans.length > 0) {
-        paintSpanHighlights(context, margins.top, context.canvas.height - margins.bottom, highlightSpans)
+        paintSpanHighlights(context, margins.top, context.canvas.height - margins.bottom - margins.top, highlightSpans)
     }
 }
 


### PR DESCRIPTION
Moved highlight-region computation into TimeScrollView, which means it now uses the correct (post-margin) width for projecting into the drawing space. Happily, this also makes it even easier to adapt other views that build on TSV to include highlight regions (just add it to the data and make sure it gets passed through).

Note that we may need to revisit the raster plot view; from a cursory glance at this it seems like it would be making a similar mistake, but we probably would've noticed by now. Let's double check when we're more fresh.

Incidentally fixed the vertical dimension on the bar highlights (they were drawing too tall).