### PR TITLE
180 top toolbars

### DIFF
--- a/src/views/MultiTimeseries/MultiTimeseriesView.css
+++ b/src/views/MultiTimeseries/MultiTimeseriesView.css
@@ -1,0 +1,21 @@
+.MultiTimeseriesViewParent {
+    position: relative;
+    left: 0;
+    top: 0;
+}
+
+.MultiTimeseriesViewLabels {
+    position: absolute;
+    writing-mode: vertical-lr;
+    transform: rotate(-180deg);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    left: 0;
+    top: 0;
+}
+
+.MultiTimeseriesViewContent {
+    position: absolute;
+    top: 0;
+}

--- a/src/views/MultiTimeseries/MultiTimeseriesView.tsx
+++ b/src/views/MultiTimeseries/MultiTimeseriesView.tsx
@@ -1,4 +1,7 @@
+import { useTimeRange } from 'contexts/RecordingSelectionContext';
 import React, { FunctionComponent, useMemo } from 'react';
+import TimeWidgetToolbarEntries from 'views/common/TimeWidgetToolbarEntries';
+import ViewToolbar from "views/common/ViewToolbar";
 import { MultiTimeseriesViewData } from './MultiTimeseriesViewData';
 import ViewWrapper from './ViewWrapper';
 
@@ -16,11 +19,27 @@ const MultiTimeseriesView: FunctionComponent<Props> = ({data, width, height}) =>
         overflowY: 'auto'
     }), [width, height])
 
+    const { zoomRecordingSelection, panRecordingSelection } = useTimeRange()
+    const timeControlActions = useMemo(() => {
+        if (!zoomRecordingSelection || !panRecordingSelection) return []
+        return TimeWidgetToolbarEntries({zoomRecordingSelection, panRecordingSelection})
+    }, [zoomRecordingSelection, panRecordingSelection])
+    const horizontalToolbarTopPadding = 15
+    const toolbarHeight = 30
+    const effectiveHeight = height - toolbarHeight - horizontalToolbarTopPadding
+
     const total_height_allocated = data.panels.reduce((total, panel) => total + (panel?.relativeHeight ?? 1), 0)
-    const unit_height = Math.floor(height / total_height_allocated)
+    const unit_height = Math.floor(effectiveHeight / total_height_allocated)
 
     return (
         <div style={divStyle}>
+            <ViewToolbar
+                width={width}
+                height={toolbarHeight}
+                topPadding={horizontalToolbarTopPadding}
+                customActions={timeControlActions}
+                useHorizontalLayout={true}
+            />
             {
                 data.panels.map((panel, ii) => (
                     <div key={ii}>

--- a/src/views/MultiTimeseries/ViewWrapper.tsx
+++ b/src/views/MultiTimeseries/ViewWrapper.tsx
@@ -2,6 +2,7 @@ import getFileData from 'figurl/getFileData';
 import { Sha1Hash } from 'figurl/viewInterface/kacheryTypes';
 import React, { FunctionComponent, useEffect, useMemo, useState } from 'react';
 import View, { TimeseriesLayoutOpts } from 'View';
+import './MultiTimeseriesView.css';
 
 type Props = {
     label: string
@@ -58,40 +59,27 @@ const ViewWrapper: FunctionComponent<Props> = ({ label, figureDataSha1, isBottom
     )
 
     const parentDivStyle: React.CSSProperties = useMemo(() => ({
-        position: 'relative',
-        left: 0,
-        top: 0,
         width,
         height
     }), [width, height])
 
     const labelDivStyle: React.CSSProperties = useMemo(() => ({
-        position: 'absolute',
-        writingMode: 'vertical-lr',
-        transform: 'rotate(-180deg)',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        left: 0,
-        top: 0,
         width: labelWidth,
         height
     }), [labelWidth, height])
 
     const contentDivStyle: React.CSSProperties = useMemo(() => ({
-        position: 'absolute',
         left: labelWidth,
-        top: 0,
         width: contentWidth,
         height
     }), [labelWidth, contentWidth, height])
 
     return (
-        <div style={parentDivStyle}>
-            <div style={labelDivStyle}>
+        <div className={"MultiTimeseriesViewParent"} style={parentDivStyle}>
+            <div className={"MultiTimeseriesViewLabels"} style={labelDivStyle}>
                 {label}
             </div>
-            <div style={contentDivStyle}>
+            <div className={"MultiTimeseriesViewContent"} style={contentDivStyle}>
                 {content}
             </div>
         </div>

--- a/src/views/RasterPlot/TimeScrollView/TimeScrollView.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TimeScrollView.tsx
@@ -210,7 +210,7 @@ export const filterAndProjectHighlightSpans = (highlightIntervals: HighlightInte
         const filteredSpanSet = filterTimeRanges(spanSet.intervalStarts, spanSet.intervalEnds, visibleTimeStartSeconds, visibleTimeEndSeconds)
         const pixelSpanStartsAndWidths = convertStartAndEndTimesToPixelRects(filteredSpanSet[0], filteredSpanSet[1], spanTransform)
         const pixelSpans = pixelSpanStartsAndWidths[0].map((start, index) => {return {start, width: pixelSpanStartsAndWidths[1][index]} as PixelSpan})
-        // something with the color if it were provided which we don't support here
+        // TODO: something with the color if it were provided which we don't support here
         return { pixelSpans, color: spanSet.color } as PixelHighlightSpanSet
     })
 

--- a/src/views/common/ToolbarStyles.css
+++ b/src/views/common/ToolbarStyles.css
@@ -1,0 +1,12 @@
+.VerticalToolbar {
+    overflow: hidden;
+    position: absolute;
+}
+
+.HorizontalToolbar {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+    margin: auto;
+}

--- a/src/views/common/ViewToolbar.tsx
+++ b/src/views/common/ViewToolbar.tsx
@@ -6,13 +6,10 @@ interface Props {
     width: number
     height: number
     top?: number
+    topPadding?: number
     customActions?: any[] | null
     useHorizontalLayout?: boolean
 }
-
-// interface PropsPlus extends Props {
-//     controls: JSX.Element[]
-// }
 
 const iconButtonStyle = {paddingLeft: 6, paddingRight: 6, paddingTop: 4, paddingBottom: 4}
 
@@ -152,50 +149,20 @@ const rectifyElements = (elements?: any[] | null): ToolbarElement[] => {
     }))
 }
 
-// const HorizontalToolbar: FunctionComponent<PropsPlus> = (props) => {
-//     const { controls } = props
-//     // in horizontal layout, width and height should have different values from in vertical layout...
-//     // NEED TO SET PADDING TO CENTER THE ELEMENT MAYBE
-//     const toolbarStyle = useMemo(() => ({
-//         width: props.width, // need this?
-//         height: props.height,
-//         top: props.top ?? 0,
-//     }), [props.width, props.height, props.top])
-
-//     return (<div className="HorizontalToolbar" style={{...toolbarStyle}}>
-//         {controls}
-//     </div>)
-// }
-
-// const VerticalToolbar: FunctionComponent<PropsPlus> = (props) => {
-//     const { controls } = props
-//     const toolbarStyle = useMemo(() => ({
-//         width: props.width,
-//         height: props.height,
-//         top: props.top ?? 0,
-//     }), [props.width, props.height, props.top])
-//     // const elements: ToolbarElement[] = useMemo(() => rectifyElements(props.customActions), [props.customActions])
-//     // // The 'key' prop won't ever get used in this way, because the ToolbarItem is really a catch-all that gets replaced
-//     // // with more specific components, but this makes React happier.
-//     // const renderedElements = useMemo(() => elements.map((e) => <ToolbarItem {...e} key={e.elementIndex}/>), [elements])
-//     return (
-//         <div className="VerticalToolbar" style={{...toolbarStyle}}>
-//             {controls}
-//         </div>
-//     );
-// }
-
 const ViewToolbar: FunctionComponent<Props> = (props) => {
     const rectifiedControls = useMemo(() => rectifyElements(props.customActions), [props.customActions])
     const renderedControls = useMemo(() =>
         rectifiedControls.map((e) => <ToolbarItem {...e} useHorizontalLayout={props.useHorizontalLayout} />),
         [rectifiedControls, props.useHorizontalLayout])
 
+    // NOTE: It's the parent's responsibility to make sure the width/height/top properties are set in a way that makes sense
+    // for the requested layout (vertical or horizontal).
     const toolbarStyle = useMemo(() => ({
         width: props.width,
         height: props.height,
         top: props.top ?? 0,
-    }), [props.width, props.height, props.top])
+        paddingTop: props.topPadding ?? 0
+    }), [props.width, props.height, props.top, props.topPadding])
 
     const className = props.useHorizontalLayout ? "HorizontalToolbar" : "VerticalToolbar"
 
@@ -204,10 +171,6 @@ const ViewToolbar: FunctionComponent<Props> = (props) => {
             {renderedControls}
         </div>
     )
-
-    // return useHorizontalLayout
-    //     ? <HorizontalToolbar {...props} controls={renderedControls} />
-    //     : <VerticalToolbar {...props} controls={renderedControls} />
 }
 
 export default ViewToolbar

--- a/src/views/common/ViewToolbar.tsx
+++ b/src/views/common/ViewToolbar.tsx
@@ -1,12 +1,18 @@
 import { Checkbox, FormGroup, IconButton, Switch } from '@material-ui/core';
 import React, { FunctionComponent, useMemo } from 'react';
+import "./ToolbarStyles.css";
 
 interface Props {
     width: number
     height: number
     top?: number
     customActions?: any[] | null
+    useHorizontalLayout?: boolean
 }
+
+// interface PropsPlus extends Props {
+//     controls: JSX.Element[]
+// }
 
 const iconButtonStyle = {paddingLeft: 6, paddingRight: 6, paddingTop: 4, paddingBottom: 4}
 
@@ -23,119 +29,185 @@ type ToolbarElement = {
     contentAlwaysShowDecimal?: boolean
     // TODO: Support for indeterminate state for checkboxes?
     elementIndex: number
+    useHorizontalLayout?: boolean
 }
 
-const ToolbarItem: FunctionComponent<ToolbarElement> = (props: ToolbarElement) => {
-    if (props.type === 'button') {
-        let color: 'inherit' | 'primary' | 'secondary' = 'inherit'
-        // in general, 'secondary' color scheme seems to look more like selection than 'primary' does
-        if (props.selected) color = 'secondary'
-        return (
-            <span title={props.title} key={props.elementIndex + '-span'}>
-                <IconButton
-                    title={props.title}
-                    onClick={props.onClick}
-                    key={props.elementIndex}
-                    color={color}
-                    style={iconButtonStyle}
-                    disabled={props.disabled ? true : false}>
-                    {props.icon}
-                </IconButton>
-            </span>
-        )
-    } else if (props.type === 'divider') {
-        return <hr key={props.elementIndex} />
-    } else if (props.type === 'text') {
-        const numericContent: number = Number.isFinite(props.content)
-            ? props.content as any as number
-            : 0
-        const sigFigs = props.contentSigFigs || 0
-        const roundsToInt = Math.abs(numericContent - Math.round(numericContent)) * (10**(sigFigs + 1)) < 1
-        const _content = Number.isFinite(props.content)
-            ? roundsToInt && !props.contentAlwaysShowDecimal
-                ? Math.round(numericContent) + ''
-                : (numericContent).toFixed(props.contentSigFigs || 2)
-            : (props.content || '')
-        return (
-            <div
-                key={props.elementIndex}
+const ToolbarButton: FunctionComponent<ToolbarElement> = (props: ToolbarElement) => {
+    const color = props.selected ? 'secondary' : 'inherit'
+    return (
+        <span title={props.title} key={props.elementIndex + '-span'}>
+            <IconButton
                 title={props.title}
-                style={{textAlign: 'center', fontWeight: 'bold', cursor: 'default'}}
-            >
-                {_content}
-            </div>
-        )
-    } else if (props.type === 'toggle') {
-        if (props.subtype === 'checkbox') {
-            return (
-                <Checkbox
-                    key={props.elementIndex}
-                    checked={props.selected}
-                    onClick={props.onClick}
-                    style={{padding: 1, paddingLeft: 6 }}
-                    title={props.title}
-                    disabled={props.disabled}
-                />
-            )
-        }
-        else if (props.subtype === 'slider') {
-            // TODO: This actually suggests that we could do a better job of rewriting this entire section of functionality
-            // to better support accessibility practices/logical form-control grouping.
-            // (I.e. probably everything should be in a FormGroup or something.)
-            // I don't know enough to do this right now, but we'll want to come back to it.
-            // TODO: Compare this with what we do in LockableSelectUnitsWidget.
-            return (
-                <FormGroup key={props.elementIndex}>
-                    <Switch
-                            checked={props.selected}
-                            size={"small"} // TODO: make styling more configurable
-                            style={{left: -3}} // Note: this seems to center it in the 36-pixel spaces we've been using.
-                                               // There's probably a better way to do this...
-                            onChange={props.onClick}
-                            disabled={props.disabled}
-                            title={props.title}
-                    />
-                </FormGroup>
-            )
-        }
-        else {
+                onClick={props.onClick}
+                key={props.elementIndex}
+                color={color}
+                style={iconButtonStyle}
+                disabled={props.disabled ? true : false}>
+                {props.icon}
+            </IconButton>
+        </span>
+    )
+}
+
+const ToolbarDivider: FunctionComponent<ToolbarElement> = (props: ToolbarElement) => {
+    return props.useHorizontalLayout ? <></> : <hr key={props.elementIndex} />
+}
+
+const ToolbarText: FunctionComponent<ToolbarElement> = (props: ToolbarElement) => {
+    const numericContent: number = Number.isFinite(props.content)
+        ? props.content as any as number
+        : 0
+    const sigFigs = props.contentSigFigs || 0
+    const roundsToInt = Math.abs(numericContent - Math.round(numericContent)) * (10**(sigFigs + 1)) < 1
+    const _content = Number.isFinite(props.content)
+        ? roundsToInt && !props.contentAlwaysShowDecimal
+            ? Math.round(numericContent) + ''
+            : (numericContent).toFixed(props.contentSigFigs || 2)
+        : (props.content || '')
+    const tagType = props.useHorizontalLayout ? 'span' : 'div'
+    return React.createElement(
+        tagType,
+        {
+            key: props.elementIndex,
+            title: props.title,
+            style: {textAlign: 'center', fontWeight: 'bold', cursor: 'default'}
+        },
+        _content
+    )
+}
+
+const ToolbarToggle: FunctionComponent<ToolbarElement> = (props: ToolbarElement) => {
+    switch (props.subtype) {
+        case 'checkbox':
+            return <ToolbarCheckbox {...props} />
+        case 'slider':
+            return <ToolbarSlider {...props} />
+        default:
             return <span key={props.elementIndex}>ERROR: Bad toggle subtype {props.subtype}</span>
-        }
-    } else {
-        return <span key={props.elementIndex} />
     }
 }
 
+const ToolbarCheckbox: FunctionComponent<ToolbarElement> = (props: ToolbarElement) => {
+    return (
+        <Checkbox
+            key={props.elementIndex}
+            checked={props.selected}
+            onClick={props.onClick}
+            style={{padding: 1, paddingLeft: 6 }}
+            title={props.title}
+            disabled={props.disabled}
+        />
+    )
+}
+
+const ToolbarSlider: FunctionComponent<ToolbarElement> = (props: ToolbarElement) => {
+    // TODO: This actually suggests that we could do a better job of rewriting this entire section of functionality
+    // to better support accessibility practices/logical form-control grouping.
+    // (I.e. probably everything should be in a FormGroup or something.)
+    // I don't know enough to do this right now, but we'll want to come back to it.
+    // TODO: Compare this with what we do in LockableSelectUnitsWidget.
+    return (
+        <FormGroup key={props.elementIndex}>
+            <Switch
+                    checked={props.selected}
+                    size={"small"} // TODO: make styling more configurable
+                    style={{left: -3}} // Note: this seems to center it in the 36-pixel spaces we've been using.
+                                        // There's probably a better way to do this...
+                    onChange={props.onClick}
+                    disabled={props.disabled}
+                    title={props.title}
+            />
+        </FormGroup>
+    )
+}
+
+const ToolbarItem: FunctionComponent<ToolbarElement> = (props: ToolbarElement) => {
+    switch (props.type) {
+        case 'button':
+            return <ToolbarButton {...props} />
+        case 'divider':
+            return <ToolbarDivider {...props} />
+        case 'text':
+            return <ToolbarText {...props} />
+        case 'toggle':
+            return <ToolbarToggle {...props} />
+        default:
+            return <span key={props.elementIndex} />
+   }
+}
+
+const rectifyElements = (elements?: any[] | null): ToolbarElement[] => {
+    return (elements || []).map((e, ii) => ({
+        type: e.type || 'button',
+        subtype: e.subtype,
+        title: e.title,
+        onClick: e.callback,
+        icon: e.icon || '',
+        selected: e.selected,
+        disabled: e.disabled,
+        content: e.content,
+        contentSigFigs: e.contentSigFigs,
+        contentAlwaysShowDecimal: e.boolean,
+        elementIndex: ii
+    }))
+}
+
+// const HorizontalToolbar: FunctionComponent<PropsPlus> = (props) => {
+//     const { controls } = props
+//     // in horizontal layout, width and height should have different values from in vertical layout...
+//     // NEED TO SET PADDING TO CENTER THE ELEMENT MAYBE
+//     const toolbarStyle = useMemo(() => ({
+//         width: props.width, // need this?
+//         height: props.height,
+//         top: props.top ?? 0,
+//     }), [props.width, props.height, props.top])
+
+//     return (<div className="HorizontalToolbar" style={{...toolbarStyle}}>
+//         {controls}
+//     </div>)
+// }
+
+// const VerticalToolbar: FunctionComponent<PropsPlus> = (props) => {
+//     const { controls } = props
+//     const toolbarStyle = useMemo(() => ({
+//         width: props.width,
+//         height: props.height,
+//         top: props.top ?? 0,
+//     }), [props.width, props.height, props.top])
+//     // const elements: ToolbarElement[] = useMemo(() => rectifyElements(props.customActions), [props.customActions])
+//     // // The 'key' prop won't ever get used in this way, because the ToolbarItem is really a catch-all that gets replaced
+//     // // with more specific components, but this makes React happier.
+//     // const renderedElements = useMemo(() => elements.map((e) => <ToolbarItem {...e} key={e.elementIndex}/>), [elements])
+//     return (
+//         <div className="VerticalToolbar" style={{...toolbarStyle}}>
+//             {controls}
+//         </div>
+//     );
+// }
+
 const ViewToolbar: FunctionComponent<Props> = (props) => {
+    const rectifiedControls = useMemo(() => rectifyElements(props.customActions), [props.customActions])
+    const renderedControls = useMemo(() =>
+        rectifiedControls.map((e) => <ToolbarItem {...e} useHorizontalLayout={props.useHorizontalLayout} />),
+        [rectifiedControls, props.useHorizontalLayout])
+
     const toolbarStyle = useMemo(() => ({
         width: props.width,
         height: props.height,
         top: props.top ?? 0,
-        overflow: 'hidden'
     }), [props.width, props.height, props.top])
-    const elements: ToolbarElement[] = useMemo(() => {
-        return (props.customActions || []).map((e, ii) => ({
-            type: e.type || 'button',
-            subtype: e.subtype,
-            title: e.title,
-            onClick: e.callback,
-            icon: e.icon || '',
-            selected: e.selected,
-            disabled: e.disabled,
-            content: e.content,
-            contentSigFigs: e.contentSigFigs,
-            contentAlwaysShowDecimal: e.boolean,
-            elementIndex: ii
-        }))
-    }, [props.customActions])
-    // The 'key' prop won't ever get used in this way, because the ToolbarItem is really a catch-all that gets replaced
-    // with more specific components, but this makes React happier.
-    const renderedElements = useMemo(() => elements.map((e) => <ToolbarItem {...e} key={e.elementIndex}/>), [elements])
+
+    const className = props.useHorizontalLayout ? "HorizontalToolbar" : "VerticalToolbar"
+
     return (
-        <div className="ViewToolBar" style={{position: 'absolute', ...toolbarStyle}}>
-            {renderedElements}
+        <div className={className} style={{...toolbarStyle}}>
+            {renderedControls}
         </div>
-    );
+    )
+
+    // return useHorizontalLayout
+    //     ? <HorizontalToolbar {...props} controls={renderedControls} />
+    //     : <VerticalToolbar {...props} controls={renderedControls} />
 }
 
 export default ViewToolbar


### PR DESCRIPTION
Sample: https://www.figurl.org/f?v=http://localhost:3000&d=7086880aeb347d2b2a1f71e2638f7560b67e678e&channel=flatiron1&label=Jaq_03_12_visualization_data2

![image](https://user-images.githubusercontent.com/2347301/156408938-daa085cd-8f07-42ed-a9e4-1f99f4307821.png)

This PR addresses SortingView issue #180, to display button-based controls for the `MultiTimeseriesView`, which are normally present alongside each `TimescrollView` element but are suppressed in the composite view.

This has been done. Note that the only controls which are exposed are those which load by default with any `TimescrollView`, i.e. those provided by the `TimeWidgetToolbarEntries` function in `views/common/TimeWidgetToolbarEntries.tsx`. (The needed callbacks for this are provided by a hook on the `RecordingSelectionContext`.) This means any toolbar elements specific to a particular view (like the amplitude modification in the Average Waveforms view, though that isn't a time series view) will not be displayed.

I considered trying to probe all contents for extra controls, but I don't think any views actually use them right now; we might consider adding this functionality in the future if it becomes necessary. If we were to do this, we should probably expand and strengthen the typing of the views composed into `MultiTimeseriesView`.

I took the opportunity to tidy up some parts of the implementation of `ViewToolbar.tsx`. Each recognized control type is now returned by its own function, which separates the control implementation from the process of selecting which component to use. It might be advisable to use more specific prop sets for the control types and cast the input props appropriately (as well as doing more type checking) but this seems more effort than it's worth presently.

The following examples show that these changes to `ViewToolbar` resulted in no change when using the vertical layout:

- https://www.figurl.org/f?v=http://localhost:3000&d=3efdf652e24633ba8345fb6a02af9d01fc67e5d1&channel=flatiron1&label=SPANS_TEST
- https://www.figurl.org/f?v=http://localhost:3000&d=6326838558011a729862a3d8915f2f3e9210e990&channel=franklab2&label=J1620210531_.nwb_raw%20data%20valid%20times%20no%20premaze%20no%20home_24 (Click "average waveforms")

We don't have specific quantitative metrics on performance, but anecdotally it seems like the button controls respond a little bit slower than the mouse interactions (wheel and dragging). We may wish to investigate performance for these tools at some point in the future.