### PR TITLE
Add support for sophisticated y-axis information.

### DIFF
--- a/src/View.tsx
+++ b/src/View.tsx
@@ -21,6 +21,7 @@ import { ViewData } from './ViewData';
 export type TimeseriesLayoutOpts = {
     hideToolbar?: boolean
     hideTimeAxis?: boolean
+    useYAxis?: boolean
 }
 
 type Props = {

--- a/src/views/Epochs/EpochsView.tsx
+++ b/src/views/Epochs/EpochsView.tsx
@@ -3,8 +3,7 @@ import { matrix, multiply } from 'mathjs'
 import React, { FunctionComponent, useCallback, useMemo } from 'react'
 import { TimeseriesLayoutOpts } from 'View'
 import { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries'
-import { useTimeseriesMargins } from 'views/PositionPlot/PositionPlotView'
-import TimeScrollView, { TimeScrollViewPanel, use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond } from '../RasterPlot/TimeScrollView/TimeScrollView'
+import TimeScrollView, { TimeScrollViewPanel, use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond, useTimeseriesMargins } from '../RasterPlot/TimeScrollView/TimeScrollView'
 import { EpochData, EpochsViewData } from './EpochsViewData'
 
 type Props = {

--- a/src/views/MultiTimeseries/ViewWrapper.tsx
+++ b/src/views/MultiTimeseries/ViewWrapper.tsx
@@ -36,7 +36,8 @@ const ViewWrapper: FunctionComponent<Props> = ({ label, figureDataSha1, isBottom
     const timeseriesLayoutOpts: TimeseriesLayoutOpts = useMemo(() => {
         return {
             hideToolbar: true,
-            hideTimeAxis: !isBottomPanel
+            hideTimeAxis: !isBottomPanel,
+            useYAxis: true // TODO: THIS IS FOR TESTING, REVERT ME
         }
     }, [isBottomPanel])
 

--- a/src/views/PositionPdfPlot/PositionPdfPlotWidget.tsx
+++ b/src/views/PositionPdfPlot/PositionPdfPlotWidget.tsx
@@ -3,8 +3,7 @@ import { matrix, multiply } from 'mathjs'
 import React, { FunctionComponent, useCallback, useMemo } from 'react'
 import { TimeseriesLayoutOpts } from 'View'
 import { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries'
-import { useTimeseriesMargins } from 'views/PositionPlot/PositionPlotView'
-import TimeScrollView, { TimeScrollViewPanel, use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond } from '../RasterPlot/TimeScrollView/TimeScrollView'
+import TimeScrollView, { TimeScrollViewPanel, use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond, useTimeseriesMargins } from '../RasterPlot/TimeScrollView/TimeScrollView'
 import useFetchCache from './useFetchCache'
 
 export type FetchSegmentQuery = {

--- a/src/views/RasterPlot/RasterPlotView.tsx
+++ b/src/views/RasterPlot/RasterPlotView.tsx
@@ -5,9 +5,8 @@ import React, { FunctionComponent, useCallback, useMemo } from 'react'
 import { TimeseriesLayoutOpts } from 'View'
 import colorForUnitId from 'views/common/colorForUnitId'
 import { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries'
-import { useTimeseriesMargins } from 'views/PositionPlot/PositionPlotView'
 import { RasterPlotViewData } from './RasterPlotViewData'
-import TimeScrollView, { use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond } from './TimeScrollView/TimeScrollView'
+import TimeScrollView, { use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond, useTimeseriesMargins } from './TimeScrollView/TimeScrollView'
 
 type Props = {
     data: RasterPlotViewData

--- a/src/views/RasterPlot/TimeScrollView/TSVAxesLayer.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TSVAxesLayer.tsx
@@ -1,5 +1,6 @@
 import BaseCanvas from 'FigurlCanvas/BaseCanvas';
 import React, { useMemo } from 'react';
+import { TickSet } from 'views/common/TimeScrollView/YAxisTicks';
 import { paintAxes } from './paint';
 import { TimeScrollViewPanel, TimeTick } from './TimeScrollView';
 
@@ -7,6 +8,7 @@ export type TSVAxesLayerProps<T extends {[key: string]: any}> = {
     panels: TimeScrollViewPanel<T>[]
     timeRange: [number, number]
     timeTicks: TimeTick[]
+    yTickSet?: TickSet
     margins: {left: number, right: number, top: number, bottom: number}
     selectedPanelKeys: string[]
     panelHeight: number
@@ -17,10 +19,10 @@ export type TSVAxesLayerProps<T extends {[key: string]: any}> = {
 }
 
 const TSVAxesLayer = <T extends {[key: string]: any}>(props: TSVAxesLayerProps<T>) => {
-    const {width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, margins, selectedPanelKeys, hideTimeAxis} = props
+    const {width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, yTickSet, margins, selectedPanelKeys, hideTimeAxis} = props
     const drawData = useMemo(() => ({
-        width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, margins, selectedPanelKeys, hideTimeAxis
-    }), [width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, margins, selectedPanelKeys, hideTimeAxis])
+        width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, yTickSet, margins, selectedPanelKeys, hideTimeAxis
+    }), [width, height, panels, panelHeight, perPanelOffset, timeRange, timeTicks, yTickSet, margins, selectedPanelKeys, hideTimeAxis])
 
     return (
         <BaseCanvas

--- a/src/views/RawTracesPlot/RawTracesPlotView.tsx
+++ b/src/views/RawTracesPlot/RawTracesPlotView.tsx
@@ -2,12 +2,11 @@ import { useRecordingSelectionTimeInitialization, useTimeRange } from 'contexts/
 import { matrix, multiply } from 'mathjs'
 import React, { FunctionComponent, useCallback, useMemo, useState } from 'react'
 import { TimeseriesLayoutOpts } from 'View'
+import AmplitudeScaleToolbarEntries from 'views/common/AmplitudeScaleToolbarEntries'
 import colorForUnitId from 'views/common/colorForUnitId'
 import { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries'
-import { useTimeseriesMargins } from 'views/PositionPlot/PositionPlotView'
+import TimeScrollView, { use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond, useTimeseriesMargins } from '../RasterPlot/TimeScrollView/TimeScrollView'
 import { RawTracesPlotViewData } from './RawTracesPlotViewData'
-import TimeScrollView, { use1dTimeToPixelMatrix, usePanelDimensions, usePixelsPerSecond } from '../RasterPlot/TimeScrollView/TimeScrollView'
-import AmplitudeScaleToolbarEntries from 'views/common/AmplitudeScaleToolbarEntries'
 
 type Props = {
     data: RawTracesPlotViewData

--- a/src/views/common/TimeScrollView/YAxisTicks.tsx
+++ b/src/views/common/TimeScrollView/YAxisTicks.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react'
+
+type YAxisProps = {
+    datamin?: number
+    datamax?: number
+    pixelHeight: number
+}
+
+export type Step = {
+    label: string,
+    dataValue: number,
+    pixelValue?: number,
+    isMajor: boolean
+}
+
+export type TickSet = {
+    ticks: Step[],
+    datamax: number,
+    datamin: number
+}
+
+const minGridSpacingPx = 26
+const maxGridSpacingPx = 60
+
+const TRUNCATE_UNCHANGED_HIGHER_ORDER_DIGITS = true
+
+const range = (min: number, max: number, step: number, base: number) => {
+    return Array(Math.ceil((max - base)/step))
+        .fill(0)
+        .map((x, ii) => base + ii * step)
+        .filter(x => x > min)
+}
+
+const fitGridLines = (minGridLines: number, maxGridLines: number, range: number, scale: number = 0): {step: number, scale: number} => {
+    const steps = [1, 2, 5]
+    const realizedScale = Math.pow(10, scale)
+    const results = steps.map((s) => {
+        const fit = range/(s * realizedScale)
+        if (fit > minGridLines && fit < maxGridLines) {
+            return {step: s, scale: scale}
+        }
+        // this means the step size is too big. This shouldn't really happen without finding an acceptable step size first,
+        // but we'll check for it later just in case.
+        if (fit < minGridLines) { return {step: -1, scale: -1} }
+        return {step: 0, scale: 0}
+    })
+    return results.find(r => r.step > 0)
+        ?? results.find(r => r.step === -1)
+        ?? fitGridLines(minGridLines, maxGridLines, range, scale + 1)
+}
+
+const computeInvariant = (min: number, max: number) => {
+    // Identify all the high-order digits that don't change between the range min and max, &
+    // suppress them for tick labeling purposes, to keep labels from getting too wide or
+    // obscuring the actual change between ticks.
+    // (We'll continue to display one digit higher than the actual range.)
+    // (This may be undesirable--it's not really that commonly done...)
+    let invariant = 0
+    const maxScale = Math.trunc(Math.log10(max))
+    if (Math.trunc(Math.log10(min)) !== maxScale) return invariant
+    const rangeScale = Math.trunc(Math.log10(max - min))
+    if (maxScale <= rangeScale) return invariant // can happen with a negative minimum
+    const oneOmGreaterThanRange = rangeScale + 1
+    const realizedMultiplier = Math.pow(10, -oneOmGreaterThanRange)
+    const maxStr = Math.trunc(max * realizedMultiplier).toString()
+    const minStr = Math.trunc(min * realizedMultiplier).toString()
+    for (const [index, digit] of [...maxStr].entries()) {
+        if (digit !== minStr[index]) {
+            invariant = invariant * Math.pow(10, (index - oneOmGreaterThanRange))
+            break
+        }
+        invariant = invariant * 10 + parseInt(digit)
+    }
+    return invariant * Math.pow(10, oneOmGreaterThanRange)
+}
+
+const alignWithStepSize = (min: number, stepScale: number) => {
+    // Return a number a) lower than the data minimum and b) with a 0 in the stepSize-place.
+    // So convert min to 1 place bigger than step scale, then floor.
+    const floor = Math.floor(min * Math.pow(10, -(stepScale + 1)))
+    const rescaled = floor * Math.pow(10, stepScale + 1)
+    return rescaled
+}
+
+const makeStep = (raw: number, base: number, scale: number): Step => {
+    const trimmed = raw - (TRUNCATE_UNCHANGED_HIGHER_ORDER_DIGITS ? base : 0)
+    const scaled = Math.trunc(trimmed * Math.pow(10, -scale))
+    const isMajor = scaled % 10 === 0
+    const label =  Math.abs(scale) > 3 ? `${(scaled/10).toFixed(1)}e${scale + 1}` : `${scaled * Math.pow(10, scale)}`
+    return {label, isMajor, dataValue: raw}
+}
+
+const enumerateScaledSteps = (base: number, datamin: number, datamax: number, stepsize: number, scale: number): Step[] => {
+    const stepValues = range(datamin, datamax, stepsize, base)
+    const invariantAboveRange = computeInvariant(datamin, datamax)
+    const steps = stepValues.map(v => makeStep(v, invariantAboveRange, scale))
+
+    return steps
+}
+
+const useYAxisTicks = (props: YAxisProps) => {
+    const { datamin, datamax, pixelHeight } = props
+    return useMemo(() => {
+        if (datamin === undefined || datamax === undefined || datamin === datamax) return []
+        const dataRange = datamax - datamin
+    
+        const rangeScale = Math.round(Math.log10(dataRange))
+        const zoomedRangeScale = 3 - rangeScale // make sure we're counting through the range with whole numbers
+        const zoomedRange = Math.round(dataRange * (Math.pow(10, zoomedRangeScale)))
+        const minGridLines = pixelHeight / maxGridSpacingPx
+        const maxGridLines = pixelHeight / minGridSpacingPx
+        const gridInfo = fitGridLines(minGridLines, maxGridLines, zoomedRange)
+        if (gridInfo.step === -1) {
+            console.warn(`Error: Unable to compute valid y-axis step size. Suppressing display.`)
+            return []
+        }
+    
+        const scaledStep = gridInfo.step * Math.pow(10, gridInfo.scale - zoomedRangeScale)
+        const startFrom = alignWithStepSize(datamin, gridInfo.scale)
+        const steps = enumerateScaledSteps(startFrom, datamin, datamax, scaledStep, gridInfo.scale - zoomedRangeScale)
+
+        return steps
+    }, [datamax, datamin, pixelHeight])
+}
+
+export default useYAxisTicks


### PR DESCRIPTION
This PR implements support for a dynamic y-axis display mechanism. This satisfies SortingView issue #184 (labeling the extrema of the vertical axis in timeseries panels), and lays groundwork for SortingView issue #181 (allowing user-specified y-scale for TimeSeriesView-based visualizations).

It also addresses SpikeSortingView issue #38 (regarding illegible rasterplotview unit IDs) and does a few other housekeeping things (though not enough to satisfy #28 or #32, which will come later).

### Features

The y-axis tick marks implement the following features:

1. Can be turned on or off at the per-view level
2. Display min/max values of range
3. Dynamically scale the step size to keep grid line distances to an acceptable pixel distance
4. Dynamically choose major ticks (defined as those with a 0 in the step size)
5. Tick labels are displayed in scientific notation when the step size's order of magnitude is greater than 3 or less than -3.
6. Steps align consistently to the axis zero point, and do not depend on the observed minimum
7. Labeled ticks can be set to suppress invariant high-order digits from the range, to ensure that heavily zoomed views remain legible

Consider a plot drawn with a vertical span of 250 pixels. Grid lines should be spaced between 26 and 60 pixels apart, so we need an integer number of grid lines in the range [5, 9]. Assume the data values run from 91.117656 to 91.125787; the total range displayed in this plot is .008131 units.

We will scale this range to an integer, then compute step sizes of 1, 2, or 5 units at several scales until we find the first step size that creates grids with appropriate spacing. So, 8131/1, 8131/2, 8131/5, 8131/10, [...20, 50, ...] all yield too many grid lines; eventually we find that a step size of 1000 fits in the appropriate range. Resetting the scale, we should span the range from 91.117656 to 91.125787 with eight steps of size 0.001, resulting in grid lines drawn at 91.118, 91.119, 91.120, ... 91.125. The tick at 91.120 is major (as it has a 0 in the thousandths place); the other lines are minor ticks. The resulting graph will label the extrema exactly, but ticks will be labeled while suppressing the repeated higher-order digits, i.e. as 0.118, 0.119, ... 0.125, to highlight the moving scale. (This last feature may potentially be controversial; it can be toggled off easily in code, or we can later implement a user control if it would be useful in limited circumstances.)

Example:
https://www.figurl.org/f?v=http://localhost:3000&d=7086880aeb347d2b2a1f71e2638f7560b67e678e&channel=flatiron1&label=Jaq_03_12_visualization_data2
![image](https://user-images.githubusercontent.com/2347301/157948357-26aa6a82-9a2c-4d6e-aa47-132bb8f970c7.png)
(Example for 0-based linear position and speed.)

https://www.figurl.org/f?v=http://localhost:3000&d=79f878acca63c2527d2e5d99189852047b5af2c2&channel=flatiron1&label=despereaux20191125_.nwb_02_r1_13_franklab_default_hippocampus
![image](https://user-images.githubusercontent.com/2347301/157948400-29726868-54ce-4787-b237-8f14577f7146.png)
(An individual plot, whose range spans the axis 0.)

![image](https://user-images.githubusercontent.com/2347301/157948435-8ebdc902-59a4-427b-a54e-6d2dfbbb1019.png)
(The same example, dynamically rescaled just by removing unit 7, which has an outlier).

Additionally, I have added code to suppress display of the unit labels for the raster plot when there is not sufficient room to write them legibly (currently defined as having 7.2 pixels of space or more).

### Implementation

Main changes:
- src/views/common/TimeScrollView/YAxisTicks.tsx is new; it defines a hook and several functions for computing the axes, and should probably be reviewed first.
- src/views/RasterPlot/TimeScrollView/paint.ts has been updated with a significant function for painting the y-axes, modeled on the one that does the time axis. (Open question: these are quite similar; can we come up with an efficient way to reduce the duplicate code between them?)
- Same file also had some tweaks to the unit label logic. Just to say it explicitly, we're always assuming that labels will be drawn in a TimeSeriesView if they are set--they just generally aren't, except for the RasterPlotView.
- Same file, rewrote the unit highlight code in a more functional style.

Smaller changes:

- Modified the `SpikeAmplitudesView` and `PositionPlotView` component code so that they take advantage of the y-axis logic and can actually display. (It'd be nice to generalize this so it isn't needed for each component--a revision should probably get passed a function that describes how to get the data range from the component's data and lets the base `TimeSeriesView` handle axis computation from that point, rather than having the calling classes use a bunch of logic to set the range externally.
- Hook for setting margins, originally located in the `PositionPlotView` file, was moved to the `TimeSeriesView` class and given an optional parameter which allows the user to override defaults for any of the four margins.
- Had to change the signatures and imports of basically every visualization built off of the `TimeSeriesView` component to accommodate for having moved the margin-handling hook.
- `TSVAxesLayer.tsx` has been modified to accept the y-tick data.
- `TimeSeriesView` modified to add some hooks for using transformation matrices to compute the correct position of y-axis labels.


Outstanding:
- There's a couple testing changes left in this code that should be reverted (just forcing use of the y-axis display, which would otherwise need to be set in the figURL generation like other time series display options).
- Need to implement data-range-passing in more of the TimeSeriesView-derived components, so that they can use the new feature.
- Spike Amplitudes display zoom winds up changing the actual displayed range. The grid lines zoom appropriately, but they should actually be redrawn to correctly describe the new range. (Leaving this for now since it looks like it might actually have bigger problems that should be addressed in a separate ticket.)