### PR TITLE
Add unit rowset initialization to SelectUnitsWidget. Fixes #42.

### DIFF
--- a/src/views/common/SelectUnitsWidget/SelectUnitsWidget.tsx
+++ b/src/views/common/SelectUnitsWidget/SelectUnitsWidget.tsx
@@ -1,7 +1,7 @@
-import { RowSelectionAction } from 'contexts/RowSelection/RowSelectionContext';
+import { INITIALIZE_ROWS, RowSelectionAction } from 'contexts/RowSelection/RowSelectionContext';
 import { SortingRule } from 'contexts/RowSelection/RowSelectionTypes';
 import { useSortingCuration } from 'contexts/SortingCurationContext';
-import React, { FunctionComponent, useMemo } from 'react';
+import React, { FunctionComponent, useEffect, useMemo } from 'react';
 import ColorPatchUnitIdLabel, { ColorPatchUnitLabelProps, mergeGroupForUnitId } from 'views/common/SortableTableWidget/ColorPatchUnitIdLabel';
 import SortableTableWidget from 'views/common/SortableTableWidget/SortableTableWidget';
 import { SortableTableWidgetRow } from 'views/common/SortableTableWidget/SortableTableWidgetTypes';
@@ -50,6 +50,10 @@ const SelectUnitsWidget: FunctionComponent<SelectUnitsWidgetProps> = (props: Sel
             }
         })
     ), [unitIds, sortingCuration, checkboxClickHandlerGenerator])
+
+    useEffect(() => {
+        unitIdSelectionDispatch({ type: INITIALIZE_ROWS, newRowOrder: rows.map(r => r.rowIdNumeric).sort((a, b) => a - b) })
+    }, [rows, unitIdSelectionDispatch])
 
     const rowMap = useMemo(() => {
         const draft = new Map<number, SortableTableWidgetRow>()


### PR DESCRIPTION
The `SelectUnitsWidget` did not have any internal initialization of the row state it interacts with; now it does.

At present I don't think we need to add unit ID initialization to other individual components, but if they are viewed in isolation (no workspace or SelectUnitsWidget) but still require unit selection, we might need to make further revisions. (At least as of right now I don't think this will be an issue, since there's not much need to select units in isolated views, but flagging it in case it needs to be addressed in the future.)