### PR TITLE
Fixes #44. Improves labeling and scaling of y-axis ticks.

### DIFF
--- a/src/views/PositionPlot/PositionPlotView.tsx
+++ b/src/views/PositionPlot/PositionPlotView.tsx
@@ -3,7 +3,7 @@ import { matrix, multiply } from 'mathjs'
 import React, { FunctionComponent, useCallback, useMemo } from 'react'
 import { TimeseriesLayoutOpts } from 'View'
 import colorForUnitId from 'views/common/ColorHandling/colorForUnitId'
-import useYAxisTicks, { TickSet } from 'views/common/TimeScrollView/YAxisTicks'
+import useYAxisTicks from 'views/common/TimeScrollView/YAxisTicks'
 import { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries'
 import TimeScrollView, { getYAxisPixelZero, TimeScrollViewPanel, use2dPanelDataToPixelMatrix, usePanelDimensions, usePixelsPerSecond, useProjectedYAxisTicks, useTimeseriesMargins } from '../RasterPlot/TimeScrollView/TimeScrollView'
 import { PositionPlotViewData } from './PositionPlotViewData'
@@ -127,13 +127,8 @@ const PositionPlotView: FunctionComponent<Props> = ({data, timeseriesLayoutOpts,
 
     // TODO: All this computational stuff should probably get pushed to the TimeScrollView...
     const yTicks = useYAxisTicks({ datamin: valueRange.yMin, datamax: valueRange.yMax, pixelHeight: panelHeight })
-    const finalYTicks = useProjectedYAxisTicks(yTicks, pixelTransform)
-    const yTickSet: TickSet = {
-        ticks: finalYTicks,
-        datamin: valueRange.yMin,
-        datamax: valueRange.yMax
-    }
-
+    const yTickSet = useProjectedYAxisTicks(yTicks, pixelTransform)
+    
     const panels: TimeScrollViewPanel<PanelProps>[] = useMemo(() => {
         const pixelZero = getYAxisPixelZero(pixelTransform)
         // this could also be done as one matrix multiplication by concatenating the dimensions;

--- a/src/views/RasterPlot/TimeScrollView/TimeScrollView.tsx
+++ b/src/views/RasterPlot/TimeScrollView/TimeScrollView.tsx
@@ -3,7 +3,7 @@ import { abs, matrix, Matrix, multiply } from 'mathjs';
 import Splitter from 'MountainWorkspace/components/Splitter/Splitter';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { TimeseriesLayoutOpts } from 'View';
-import { Step, TickSet } from 'views/common/TimeScrollView/YAxisTicks';
+import { TickSet } from 'views/common/TimeScrollView/YAxisTicks';
 import TimeWidgetToolbarEntries, { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries';
 import { Divider, ToolbarItem } from 'views/common/Toolbars';
 import ViewToolbar from 'views/common/ViewToolbar';
@@ -97,7 +97,7 @@ export const useTimeseriesMargins = (timeseriesLayoutOpts: TimeseriesLayoutOpts 
                 } : {
                     left: 20 + yAxisLeftMargin,
                     right: 20,
-                    top: 0,
+                    top: 10,
                     bottom: hideTimeAxis ? 0 : 40
                 }
         return { ...defaultMargins, ...manualMargins}
@@ -365,15 +365,19 @@ const useTimeTicks = (startTimeSec: number | undefined, endTimeSec: number | und
     }, [startTimeSec, endTimeSec, timeToPixelMatrix, pixelsPerSecond])
 }
 
-export const useProjectedYAxisTicks = (ticks: Step[], transform: Matrix) => {
+export const useProjectedYAxisTicks = (ticks: TickSet, transform: Matrix) => {
     // transform is assumed to be the output of our use2dPanelDataToPixelMatrix
     return useMemo(() => {
+        const _ticks = ticks.ticks
         const augmentedValues = matrix([
-            new Array(ticks.length).fill(0),
-            ticks.map(t => t.dataValue),
-            new Array(ticks.length).fill(1)])
+            new Array(_ticks.length).fill(0),
+            _ticks.map(t => t.dataValue),
+            new Array(_ticks.length).fill(1)])
         const pixelValues = (multiply(transform, augmentedValues).valueOf() as number[][])[1]
-        return ticks.map((t, ii) => {return {...t, pixelValue: pixelValues[ii]}})
+        return {
+            ...ticks,
+            ticks: _ticks.map((t, ii) => {return {...t, pixelValue: pixelValues[ii]}})
+        }
     }, [ticks, transform])
 }
 

--- a/src/views/RasterPlot/TimeScrollView/paint.ts
+++ b/src/views/RasterPlot/TimeScrollView/paint.ts
@@ -74,7 +74,7 @@ const paintYTicks = (context: CanvasRenderingContext2D, tickSet: TickSet, xAxisY
     const printMax = stringMax.substring(0, 5).search(".") === -1 ? 5 : 6
     const stringMin = datamin.toString()
     const printMin = stringMin.substring(0, 5).search(".") === -1 ? 5 : 6
-    context.textBaseline = 'bottom' // WAS BOTTOM
+    context.textBaseline = 'bottom'
     context.fillText(stringMax.substring(0, printMax), labelRightEdge, topMargin)
     context.textBaseline = 'top'
     context.fillText(datamin.toString().substring(0, printMin), labelRightEdge, xAxisYCoordinate)

--- a/src/views/RasterPlot/TimeScrollView/paint.ts
+++ b/src/views/RasterPlot/TimeScrollView/paint.ts
@@ -70,11 +70,16 @@ const paintYTicks = (context: CanvasRenderingContext2D, tickSet: TickSet, xAxisY
     context.fillStyle = 'black'
     context.textAlign = 'right'
     // Range-end labels
-    context.textBaseline = 'bottom'
-    context.fillText(datamax.toFixed(0), labelRightEdge, topMargin)
-    context.textBaseline = 'middle'
-    context.fillText(datamin.toString(), labelRightEdge, xAxisYCoordinate)
+    const stringMax = datamax.toString()
+    const printMax = stringMax.substring(0, 5).search(".") === -1 ? 5 : 6
+    const stringMin = datamin.toString()
+    const printMin = stringMin.substring(0, 5).search(".") === -1 ? 5 : 6
+    context.textBaseline = 'bottom' // WAS BOTTOM
+    context.fillText(stringMax.substring(0, printMax), labelRightEdge, topMargin)
+    context.textBaseline = 'top'
+    context.fillText(datamin.toString().substring(0, printMin), labelRightEdge, xAxisYCoordinate)
 
+    context.textBaseline = 'middle'
     ticks.forEach(tick => {
         if (!tick.pixelValue) return
         const pixelValueWithMargin = tick.pixelValue + topMargin

--- a/src/views/SpikeAmplitudes/SpikeAmplitudesView.tsx
+++ b/src/views/SpikeAmplitudes/SpikeAmplitudesView.tsx
@@ -7,7 +7,7 @@ import AmplitudeScaleToolbarEntries from 'views/common/AmplitudeScaleToolbarEntr
 import colorForUnitId from 'views/common/ColorHandling/colorForUnitId'
 import LockableSelectUnitsWidget from 'views/common/SelectUnitsWidget/LockableSelectUnitsWidget'
 import useLocalSelectedUnitIds from 'views/common/SelectUnitsWidget/useLocalSelectedUnitIds'
-import useYAxisTicks, { TickSet } from 'views/common/TimeScrollView/YAxisTicks'
+import useYAxisTicks from 'views/common/TimeScrollView/YAxisTicks'
 import { DefaultToolbarWidth } from 'views/common/TimeWidgetToolbarEntries'
 import TimeScrollView, { TimeScrollViewPanel, use2dPanelDataToPixelMatrix, usePanelDimensions, usePixelsPerSecond, useProjectedYAxisTicks, useTimeseriesMargins } from '../RasterPlot/TimeScrollView/TimeScrollView'
 import { SpikeAmplitudesViewData } from './SpikeAmplitudesViewData'
@@ -144,13 +144,8 @@ const SpikeAmplitudesViewChild: FunctionComponent<ChildProps> = ({data, timeseri
         true
     )
 
-    const yTicks = useYAxisTicks({ datamin: amplitudeRange.yMin, datamax: amplitudeRange.yMax, pixelHeight: panelHeight })
-    const finalYTicks = useProjectedYAxisTicks(yTicks, pixelTransform)
-    const yTickSet: TickSet = {
-        ticks: finalYTicks,
-        datamin: amplitudeRange.yMin,
-        datamax: amplitudeRange.yMax
-    }
+    const yTicks = useYAxisTicks({ datamin: amplitudeRange.yMin, datamax: amplitudeRange.yMax, userSpecifiedZoom: ampScaleFactor, pixelHeight: panelHeight })
+    const yTickSet = useProjectedYAxisTicks(yTicks, pixelTransform)
 
     const panels: TimeScrollViewPanel<PanelProps>[] = useMemo(() => {
         return [{

--- a/src/views/common/TimeScrollView/YAxisTicks.tsx
+++ b/src/views/common/TimeScrollView/YAxisTicks.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react'
 type YAxisProps = {
     datamin?: number
     datamax?: number
+    userSpecifiedZoom?: number
     pixelHeight: number
 }
 
@@ -19,7 +20,7 @@ export type TickSet = {
     datamin: number
 }
 
-const minGridSpacingPx = 26
+const minGridSpacingPx = 23
 const maxGridSpacingPx = 60
 
 const TRUNCATE_UNCHANGED_HIGHER_ORDER_DIGITS = true
@@ -92,17 +93,30 @@ const makeStep = (raw: number, base: number, scale: number): Step => {
 
 const enumerateScaledSteps = (base: number, datamin: number, datamax: number, stepsize: number, scale: number): Step[] => {
     const stepValues = range(datamin, datamax, stepsize, base)
+    // console.log(`${(stepValues[0] - datamin)/stepsize}`)
+    // if ((stepValues[0] - datamin)/stepsize < 0.33 ) {
+    //     stepValues.shift()
+    // }
     const invariantAboveRange = computeInvariant(datamin, datamax)
     const steps = stepValues.map(v => makeStep(v, invariantAboveRange, scale))
 
     return steps
 }
 
+const emptyTickSet = {
+    ticks: [] as any as Step[],
+    datamin: 0,
+    datamax: 0
+}
+
 const useYAxisTicks = (props: YAxisProps) => {
-    const { datamin, datamax, pixelHeight } = props
+    const { datamin, datamax, userSpecifiedZoom, pixelHeight } = props
+    const yZoom = userSpecifiedZoom ?? 1
     return useMemo(() => {
-        if (datamin === undefined || datamax === undefined || datamin === datamax) return []
-        const dataRange = datamax - datamin
+        if (datamin === undefined || datamax === undefined || datamin === datamax) return emptyTickSet
+        const _dataMin = datamin / yZoom
+        const _dataMax = datamax / yZoom
+        const dataRange = _dataMax - _dataMin
     
         const rangeScale = Math.round(Math.log10(dataRange))
         const zoomedRangeScale = 3 - rangeScale // make sure we're counting through the range with whole numbers
@@ -112,15 +126,15 @@ const useYAxisTicks = (props: YAxisProps) => {
         const gridInfo = fitGridLines(minGridLines, maxGridLines, zoomedRange)
         if (gridInfo.step === -1) {
             console.warn(`Error: Unable to compute valid y-axis step size. Suppressing display.`)
-            return []
+            return emptyTickSet
         }
     
         const scaledStep = gridInfo.step * Math.pow(10, gridInfo.scale - zoomedRangeScale)
-        const startFrom = alignWithStepSize(datamin, gridInfo.scale)
-        const steps = enumerateScaledSteps(startFrom, datamin, datamax, scaledStep, gridInfo.scale - zoomedRangeScale)
+        const startFrom = alignWithStepSize(_dataMin, gridInfo.scale)
+        const steps = enumerateScaledSteps(startFrom, _dataMin, _dataMax, scaledStep, gridInfo.scale - zoomedRangeScale)
 
-        return steps
-    }, [datamax, datamin, pixelHeight])
+        return { ticks: steps, datamin: _dataMin, datamax: _dataMax }
+    }, [datamax, datamin, yZoom, pixelHeight])
 }
 
 export default useYAxisTicks

--- a/src/views/common/TimeScrollView/YAxisTicks.tsx
+++ b/src/views/common/TimeScrollView/YAxisTicks.tsx
@@ -93,10 +93,6 @@ const makeStep = (raw: number, base: number, scale: number): Step => {
 
 const enumerateScaledSteps = (base: number, datamin: number, datamax: number, stepsize: number, scale: number): Step[] => {
     const stepValues = range(datamin, datamax, stepsize, base)
-    // console.log(`${(stepValues[0] - datamin)/stepsize}`)
-    // if ((stepValues[0] - datamin)/stepsize < 0.33 ) {
-    //     stepValues.shift()
-    // }
     const invariantAboveRange = computeInvariant(datamin, datamax)
     const steps = stepValues.map(v => makeStep(v, invariantAboveRange, scale))
 


### PR DESCRIPTION
As per issue #44.

This PR comprises the following changes:

- Adjusted baselines of the labels for range extrema so they don't get hidden.
- Added a top margin on the with-axis-display TimeScrollView so that the range maximum will always be displayed.
- Truncating range extrema so we'll see the most significant digits we have room for, rather than a confusing set of the least-significant digits that happen to be hanging around.
- Adjusted tolerance on the allowable minimum tick height to avoid cases where the system couldn't find a suitable step size (and thus stopped displaying the ticks).
- `useYAxisTicks` now handles the datamin and datamax as well, and returns a `TickSet`. This adjusts for user-specified vertical zoom/scaling for SpikeAmplitudes view. Scaling the min/max values of the data in a centralized place is more organized, and lets us recompute the y-axis ticks/grid lines so they fill the intended visible range, rather than scrolling them in weird ways due to the zoom.

Outstanding issues:
- These layout solutions are, let's say, heuristic. There are probably still some combinations of window height and data range that will result in illegible values or grid lines not computing successfully.
- Recomputing y-axis values on vertical zoom is the right move, but I have not gone so far as to suppress display of data points that fall into the margin (below the x-axis). This means some data points can appear below the grid, in the figure margin. I think it's pretty clear what's happening, but we might want to put in some logic to stop drawing them if they're outside the range or whatever.
- I have seen extreme vertical zoom lead to poor display for y-tick labels (due to math issues). So far I've only seen it when radically zoomed in, so I'm not going to bother trying to fix it right now, but we should keep an eye out if it becomes an issue in practice.