### PR TITLE
Consolidated general type-validation code into validateObject.ts

### DIFF
--- a/src/ViewData.ts
+++ b/src/ViewData.ts
@@ -1,4 +1,4 @@
-import { isOneOf } from "figurl/viewInterface/kacheryTypes"
+import { isOneOf } from "figurl/viewInterface/validateObject"
 import { AutocorrelogramsViewData, isAutocorrelogramsViewData } from "views/Autocorrelograms/AutocorrelogramsViewData"
 import { AverageWaveformsViewData, isAverageWaveformsViewData } from "views/AverageWaveforms/AverageWaveformsViewData"
 import { CompositeViewData, isCompositeViewData } from "views/Composite/CompositeViewData"

--- a/src/figurl/viewInterface/FigurlRequestTypes.ts
+++ b/src/figurl/viewInterface/FigurlRequestTypes.ts
@@ -1,5 +1,5 @@
-import { ErrorMessage, FeedId, isArrayOf, isErrorMessage, isFeedId, isSha1Hash, isSubfeedHash, isSubfeedMessage, isTaskFunctionId, isTaskFunctionType, isTaskId, isTaskStatus, Sha1Hash, SubfeedHash, SubfeedMessage, TaskFunctionId, TaskFunctionType, TaskId, TaskStatus } from "./kacheryTypes"
-import validateObject, { isBoolean, isEqualTo, isOneOf, isString, optional } from "./validateObject"
+import { ErrorMessage, FeedId, isErrorMessage, isFeedId, isSha1Hash, isSubfeedHash, isSubfeedMessage, isTaskFunctionId, isTaskFunctionType, isTaskId, isTaskStatus, Sha1Hash, SubfeedHash, SubfeedMessage, TaskFunctionId, TaskFunctionType, TaskId, TaskStatus } from "./kacheryTypes"
+import validateObject, { isArrayOf, isBoolean, isEqualTo, isOneOf, isString, optional } from "./validateObject"
 
 // getFigureData
 

--- a/src/views/AverageWaveforms/AverageWaveformsViewData.ts
+++ b/src/views/AverageWaveforms/AverageWaveformsViewData.ts
@@ -1,6 +1,5 @@
 import { validateObject } from "figurl"
-import { optional } from "figurl/viewInterface/kacheryTypes"
-import { isArrayOf, isEqualTo, isNumber } from "figurl/viewInterface/validateObject"
+import { isArrayOf, isEqualTo, isNumber, optional } from "figurl/viewInterface/validateObject"
 
 type AverageWaveformData = {
     unitId: number

--- a/src/views/Composite/CompositeViewData.ts
+++ b/src/views/Composite/CompositeViewData.ts
@@ -1,6 +1,6 @@
 import { validateObject } from "figurl"
-import { isOneOf, isSha1Hash, optional, Sha1Hash } from "figurl/viewInterface/kacheryTypes"
-import { isArrayOf, isEqualTo, isNumber } from "figurl/viewInterface/validateObject"
+import { isSha1Hash, Sha1Hash } from "figurl/viewInterface/kacheryTypes"
+import { isArrayOf, isEqualTo, isNumber, isOneOf, optional } from "figurl/viewInterface/validateObject"
 import { isString } from "vega"
 
 type CVViewData = {

--- a/src/views/MountainLayout/MountainLayoutViewData.ts
+++ b/src/views/MountainLayout/MountainLayoutViewData.ts
@@ -1,6 +1,6 @@
 import { validateObject } from "figurl"
-import { isSha1Hash, optional, Sha1Hash } from "figurl/viewInterface/kacheryTypes"
-import { isArrayOf, isEqualTo } from "figurl/viewInterface/validateObject"
+import { isSha1Hash, Sha1Hash } from "figurl/viewInterface/kacheryTypes"
+import { isArrayOf, isEqualTo, optional } from "figurl/viewInterface/validateObject"
 import { isString } from "vega"
 
 type MLViewData = {

--- a/src/views/MultiTimeseries/MultiTimeseriesViewData.ts
+++ b/src/views/MultiTimeseries/MultiTimeseriesViewData.ts
@@ -1,6 +1,6 @@
 import { validateObject } from "figurl"
-import { isSha1Hash, optional, Sha1Hash } from "figurl/viewInterface/kacheryTypes"
-import { isArrayOf, isEqualTo, isNumber } from "figurl/viewInterface/validateObject"
+import { isSha1Hash, Sha1Hash } from "figurl/viewInterface/kacheryTypes"
+import { isArrayOf, isEqualTo, isNumber, optional } from "figurl/viewInterface/validateObject"
 import { isString } from "vega"
 
 type MTPanelData = {


### PR DESCRIPTION
There were duplicate definitions (with the same actual code) for most basic and simple-composite type checkers in both `kacheryTypes.ts` and `validateObject.ts`. I simply removed the duplicated definitions from `kacheryTypes.ts`, and added the general-purpose ones--like optionality and JSON-handling--to `validateObject.ts`, plus updating references.

These could also be consolidated under the `kacheryTypes.ts` header (though validation seems more general-purpose than this)--I just want to avoid having the same functions defined in multiple places.