### PR TITLE
Implement replay-rate dropdown menu selection.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-draggable": "^4.4.4",
     "react-icons": "^4.3.1",
     "react-scripts": "4.0.3",
+    "react-select": "^5.3.2",
     "react-sizeme": "^3.0.2",
     "react-vega": "^7.4.4",
     "typescript": "^4.1.2",

--- a/src/views/common/Animation/AnimationControlButtonStyles.css
+++ b/src/views/common/Animation/AnimationControlButtonStyles.css
@@ -2,3 +2,47 @@ div.AnimationControlButton span {
     padding-left: 4px;
     padding-right: 4px;
 }
+
+/* Styling for inline dropdown from https://github.com/JedWatson/react-select/issues/4201
+linking to https://codesandbox.io/s/react-select-inline-kk1u6?file=/style.css:761-1065 */
+
+.dropdown-inline {
+    display: inline-block;
+    margin: 0 0.25em;
+}
+
+.dropdown-inline .dropdown__control {
+    border: none;
+    outline: none;
+    box-shadow: none;
+    min-height: none;
+    cursor: pointer;
+}
+
+.dropdown-inline .dropdown__value-container {
+    padding: 0;
+}
+
+.dropdown-inline .dropdown__single-value {
+    position: relative;
+    transform: none;
+    max-width: none;
+}
+
+.dropdown-inline .dropdown__single-value::after {
+    content: " ";
+    position: relative;
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 5px 4px 0 4px;
+    border-color: #000000 transparent transparent transparent;
+  
+    margin-left: 0.25em;
+    top: -0.125em;
+}
+
+.dropdown-inline .dropdown__menu {
+    width: auto;
+}

--- a/src/views/common/Animation/AnimationPlaybackControls.tsx
+++ b/src/views/common/Animation/AnimationPlaybackControls.tsx
@@ -3,7 +3,7 @@ import AnimationStateControlButtons from './AnimationStateControlButtons'
 import AnimationStatePlaybackBarLayer from './AnimationStatePlaybackBarLayer'
 import { AnimationStateDispatcher } from './AnimationStateReducer'
 
-export type TPAControlsProps<T> = {
+export type AnimationPlaybackControlsProps<T> = {
     width: number
     height: number
     verticalOffset: number
@@ -12,13 +12,15 @@ export type TPAControlsProps<T> = {
     currentFrameIndex: number
     isPlaying: boolean
     playbackRate: number
+    customPlaybackRates?: number[]
+    usingRateButtons?: boolean
 }
 
 // TODO: Allow changing?
 const buttonWidthPx = 280
 
-const AnimationPlaybackControls = <T, >(props: TPAControlsProps<T>) => {
-    const { width, height, verticalOffset, dispatch, isPlaying, totalFrameCount, currentFrameIndex, playbackRate } = props
+const AnimationPlaybackControls = <T, >(props: AnimationPlaybackControlsProps<T>) => {
+    const { width, height, verticalOffset, dispatch, isPlaying, totalFrameCount, currentFrameIndex, playbackRate, usingRateButtons, customPlaybackRates } = props
     const ctrlPanelDiv = useMemo(() => {
         return (<AnimationStateControlButtons
             height={height}
@@ -26,8 +28,10 @@ const AnimationPlaybackControls = <T, >(props: TPAControlsProps<T>) => {
             isPlaying={isPlaying}
             buttonWidthPx={buttonWidthPx}
             playbackRate={playbackRate}
+            customPlaybackRates={customPlaybackRates}
+            usingRateButtons={usingRateButtons}
         />)
-    }, [height, dispatch, isPlaying, playbackRate])
+    }, [height, dispatch, isPlaying, playbackRate, customPlaybackRates, usingRateButtons])
 
     const barLayerDiv = useMemo(() => {
         return (<AnimationStatePlaybackBarLayer<T>

--- a/src/views/common/Animation/AnimationStateControlButtons.tsx
+++ b/src/views/common/Animation/AnimationStateControlButtons.tsx
@@ -1,6 +1,7 @@
 import { faAngleDown, faAngleUp, faBackward, faFastBackward, faFastForward, faForward, faPause, faPlay, faStepBackward, faStepForward } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import React, { useCallback, useMemo } from 'react'
+import Select from 'react-select'
 import './AnimationControlButtonStyles.css'
 import { AnimationStateDispatcher } from './AnimationStateReducer'
 
@@ -10,10 +11,84 @@ export type AnimationStateControlButtonsProps<T> = {
     isPlaying: boolean
     buttonWidthPx: number
     playbackRate: number
+    customPlaybackRates?: number[]
+    usingRateButtons?: boolean
 }
 
+const defaultPlaybackRates = [0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 10 ]
+const PlaybackRateDropdown = <T, >(props: AnimationStateControlButtonsProps<T>) => {
+    const { playbackRate, customPlaybackRates, usingRateButtons, dispatch } = props
+    const playbackRates = useMemo(() => {
+        const c = customPlaybackRates || []
+        return [...defaultPlaybackRates, ...c]
+    }, [customPlaybackRates])
+    const playbackRateOptions = useMemo(() => {
+        return playbackRates.map(
+            r => {return {
+                value: r,
+                label: `${r.toString().slice(0, 5)}x`
+            }}
+        )
+    }, [playbackRates])
+    const selectedRateOption = useMemo(() => {
+        if (usingRateButtons) return null
+        return playbackRateOptions.find(e => Math.abs(e.value - Math.abs(playbackRate)) < 0.001) || null
+    }, [playbackRateOptions, playbackRate, usingRateButtons])
+
+    const handleChangePlaybackRateOption = useCallback((selectedOption) => {
+        dispatch({
+            type: 'SET_REPLAY_RATE',
+            newRate: (playbackRate > 0 ? 1 : -1) * selectedOption.value
+        })
+    }, [dispatch, playbackRate])
+
+    return (
+        <span>
+            <Select
+                value={selectedRateOption}
+                options={playbackRateOptions}
+                onChange={handleChangePlaybackRateOption}
+                classNamePrefix="dropdown"
+                className="dropdown-inline"
+                components={{ IndicatorsContainer: () => null }}
+                menuPlacement="top"
+            />
+        </span>)
+}
+
+
+const PlaybackRateButtons = <T, >(props: AnimationStateControlButtonsProps<T>) => {
+    const { dispatch, playbackRate } = props
+    const getChangePlaybackSpeedHandler = useCallback((direction: 'faster' | 'slower') => {
+        const newPlayback = direction === 'faster' ? playbackRate * 1.3 : playbackRate/1.3
+        return (e: React.MouseEvent) => {
+            dispatch({
+                type: 'SET_REPLAY_RATE',
+                newRate: newPlayback
+            })
+        }
+    }, [dispatch, playbackRate])
+
+    const resolution = useMemo(() => {
+        return playbackRate > 0 ? 4 : 5
+    }, [playbackRate])
+
+    return <>
+        <span title="Decrease playback rate">
+            <FontAwesomeIcon icon={faAngleDown} onMouseDown={getChangePlaybackSpeedHandler('slower')} />
+        </span>
+        <span title="Playback rate (frames per 1/60th of a second)">
+            {`${playbackRate.toString().substring(0, resolution)}`}
+        </span>
+        <span title="Increase playback rate">
+            <FontAwesomeIcon icon={faAngleUp} onMouseDown={getChangePlaybackSpeedHandler('faster')} />
+        </span>
+    </>
+}
+
+
 const AnimationStateControlButtons = <T, >(props: AnimationStateControlButtonsProps<T>) => {
-    const { height, dispatch, isPlaying, buttonWidthPx, playbackRate } = props
+    const { height, dispatch, isPlaying, buttonWidthPx, playbackRate, usingRateButtons } = props
 
     const handlePlayPauseClick = useCallback((e: React.MouseEvent) => {
         dispatch({
@@ -37,15 +112,8 @@ const AnimationStateControlButtons = <T, >(props: AnimationStateControlButtonsPr
         })
     }, [dispatch, playbackRate])
 
-    const getChangePlaybackSpeedHandler = useCallback((direction: 'faster' | 'slower') => {
-        const newPlayback = direction === 'faster' ? playbackRate * 1.3 : playbackRate/1.3
-        return (e: React.MouseEvent) => {
-            dispatch({
-                type: 'SET_REPLAY_RATE',
-                newRate: newPlayback
-            })
-        }
-    }, [dispatch, playbackRate])
+    const rateDropdown = useMemo(() => <PlaybackRateDropdown {...props} />, [props])
+    const rateButtons = useMemo(() => <PlaybackRateButtons {...props} />, [props])
 
     const playPauseIcon = useMemo(() => {
         return isPlaying ? <FontAwesomeIcon icon={faPause} /> : <FontAwesomeIcon icon={faPlay} />
@@ -56,14 +124,18 @@ const AnimationStateControlButtons = <T, >(props: AnimationStateControlButtonsPr
         return playbackRate > 0 ? <FontAwesomeIcon icon={faStepBackward} /> : <FontAwesomeIcon icon={faStepForward} />
     }, [playbackRate])
 
-    const resolution = useMemo(() => {
-        return playbackRate > 0 ? 4 : 5
-    }, [playbackRate])
+    const rateControl = usingRateButtons ? rateButtons : rateDropdown
+    const extraSpan = usingRateButtons ? <span>&nbsp;</span> : <></>
 
     return (
         <div
             className={'AnimationControlButton'}
-            style={{position: 'absolute', textAlign: 'center', width: buttonWidthPx, height: Math.floor(height * .75), top: Math.ceil(height * .25), font: `${Math.floor(height/2)}px FontAwesome`,}}
+            style={{position: 'absolute',
+                    textAlign: 'center',
+                    width: buttonWidthPx,
+                    height: usingRateButtons ? Math.floor(height * .8) : height,
+                    top: usingRateButtons ? Math.ceil(height * .2) : 0,
+                    font: `${Math.floor(height/2)}px FontAwesome`,}}
         >
             <span onMouseDown={getArrowClickHandler('end', true)} title="Return to beginning">
                 <FontAwesomeIcon icon={faFastBackward} />
@@ -80,20 +152,10 @@ const AnimationStateControlButtons = <T, >(props: AnimationStateControlButtonsPr
             <span onMouseDown={getArrowClickHandler('end')} title="Skip to end">
                 <FontAwesomeIcon icon={faFastForward} />
             </span>
-            <span>
-                &nbsp;
-            </span>
+            {extraSpan}
+            {rateControl}
             <span onMouseDown={changeDirectionHandler} title="Reverse playback direction">
                 {directionIcon}
-            </span>
-            <span title="Decrease playback rate">
-                <FontAwesomeIcon icon={faAngleDown} onMouseDown={getChangePlaybackSpeedHandler('slower')} />
-            </span>
-            <span title="Playback rate (frames per 1/60th of a second)">
-                {`${playbackRate.toString().substring(0, resolution)}`}
-            </span>
-            <span title="Increase playback rate">
-                <FontAwesomeIcon icon={faAngleUp} onMouseDown={getChangePlaybackSpeedHandler('faster')} />
             </span>
         </div>
     )

--- a/src/views/common/Animation/AnimationStateControlButtons.tsx
+++ b/src/views/common/Animation/AnimationStateControlButtons.tsx
@@ -20,7 +20,7 @@ const PlaybackRateDropdown = <T, >(props: AnimationStateControlButtonsProps<T>) 
     const { playbackRate, customPlaybackRates, usingRateButtons, dispatch } = props
     const playbackRates = useMemo(() => {
         const c = customPlaybackRates || []
-        return [...defaultPlaybackRates, ...c]
+        return [...new Set([...defaultPlaybackRates, ...c])].sort((a: number, b: number) => a - b)
     }, [customPlaybackRates])
     const playbackRateOptions = useMemo(() => {
         return playbackRates.map(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,6 +1098,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.13.10":
+  version "7.17.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.9.tgz#d19fbf802d01a8cb6cf053a64e472d42c434ba72"
+  integrity sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
@@ -1161,10 +1168,88 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@emotion/babel-plugin@^11.7.1":
+  version "11.9.2"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.9.2.tgz#723b6d394c89fb2ef782229d92ba95a740576e95"
+  integrity sha512-Pr/7HGH6H6yKgnVFNEj2MVlreu3ADqftqjqwUvDy/OJzKFgxKeTQ+eeUf20FOTuHVkDON2iNa25rAXVYtWJCjw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/plugin-syntax-jsx" "^7.12.13"
+    "@babel/runtime" "^7.13.10"
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.5"
+    "@emotion/serialize" "^1.0.2"
+    babel-plugin-macros "^2.6.1"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^4.0.0"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+    stylis "4.0.13"
+
+"@emotion/cache@^11.4.0", "@emotion/cache@^11.7.1":
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
+  integrity sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.1.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "4.0.13"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
+
+"@emotion/memoize@^0.7.4", "@emotion/memoize@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/react@^11.8.1":
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.9.0.tgz#b6d42b1db3bd7511e7a7c4151dc8bc82e14593b8"
+  integrity sha512-lBVSF5d0ceKtfKCDQJveNAtkC7ayxpVlgOohLgXqRwqWr9bOf4TZAFFyIcNngnV6xK6X4x2ZeXq7vliHkoVkxQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/babel-plugin" "^11.7.1"
+    "@emotion/cache" "^11.7.1"
+    "@emotion/serialize" "^1.0.3"
+    "@emotion/utils" "^1.1.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@^1.0.2", "@emotion/serialize@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.3.tgz#99e2060c26c6292469fb30db41f4690e1c8fea63"
+  integrity sha512-2mSSvgLfyV3q+iVh3YWgNlUc2a9ZlDU7DjuP5MjK3AXRR0dYigCrP99aeFtaB2L/hjfEZdSThn5dsZ0ufqbvsA==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
+  integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
+
+"@emotion/unitless@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
+
+"@emotion/utils@^1.0.0", "@emotion/utils@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.1.0.tgz#86b0b297f3f1a0f2bdb08eeac9a2f49afd40d0cf"
+  integrity sha512-iRLa/Y4Rs5H/f2nimczYmS5kFJEbpiVvgN3XVfZ022IYhuNA1IRSHEizcof88LtCTXtl9S2Cxt32KgaXEu72JQ==
+
+"@emotion/weak-memoize@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
+  integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
 "@eslint/eslintrc@^0.3.0":
   version "0.3.0"
@@ -1947,7 +2032,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@^4.2.0":
+"@types/react-transition-group@^4.2.0", "@types/react-transition-group@^4.4.0":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
   integrity sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==
@@ -2788,7 +2873,7 @@ babel-plugin-jest-hoist@^26.6.2:
     "@types/babel__core" "^7.0.0"
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@2.8.0:
+babel-plugin-macros@2.8.0, babel-plugin-macros@^2.6.1:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -3692,6 +3777,13 @@ convert-source-map@^0.3.3:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-0.3.5.tgz#f1d802950af7dd2631a1febe0596550c86ab3190"
   integrity sha1-8dgClQr33SYxof6+BZZVDIarMZA=
+
+convert-source-map@^1.5.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
+  integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
+  dependencies:
+    safe-buffer "~5.1.1"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -4821,6 +4913,11 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
 escodegen@^1.14.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
@@ -5387,6 +5484,11 @@ find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@4.1.0, find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -5850,7 +5952,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7602,6 +7704,11 @@ media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
+memoize-one@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -9671,6 +9778,19 @@ react-scripts@4.0.3:
   optionalDependencies:
     fsevents "^2.1.3"
 
+react-select@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.3.2.tgz#ecee0d5c59ed4acb7f567f7de3c75a488d93dacb"
+  integrity sha512-W6Irh7U6Ha7p5uQQ2ZnemoCQ8mcfgOtHfw3wuMzG6FAu0P+CYicgofSLOq97BhjMx8jS+h+wwWdCBeVVZ9VqlQ==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+
 react-sizeme@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-3.0.2.tgz#4a2f167905ba8f8b8d932a9e35164e459f9020e4"
@@ -9681,7 +9801,7 @@ react-sizeme@^3.0.2:
     shallowequal "^1.1.0"
     throttle-debounce "^3.0.1"
 
-react-transition-group@^4.4.0:
+react-transition-group@^4.3.0, react-transition-group@^4.4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
   integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
@@ -10578,7 +10698,7 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, sourc
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.5.0, source-map@^0.5.6:
+source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -10915,6 +11035,11 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis@4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"
+  integrity sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag==
 
 supports-color@^5.3.0:
   version "5.5.0"


### PR DESCRIPTION
Fixes issue #52.

Example:
![image](https://user-images.githubusercontent.com/2347301/167932010-e357ef1e-aaf8-427d-88c3-e6d57a99a43f.png)

Used `react-select` library with some recommended modifications for inline styling to allow user to choose from a palette of replay rates instead of using the button-based stepwise adjustment. An individual component can select whether to present the button-based or dropdown-based interface based on a toggle prop.

By default the replay rate selection presents values of 0.1x, 0.25x, 0.5x, 1x, 2x, 3x, 4x, 5x, and 10x, but additional replay rates can be passed through the `customPlaybackRates` parameter; the combined list will be sorted and uniqued before being presented to the user. There is not currently any functionality to disable the default rate values; this didn't seem necessary but would be easy enough to implement if desired. Additionally, the dropdown options don't currently show negative signs while playing in reverse; this would be trivial to implement if desired.