### PR TITLE
Add base replay rate for 1:1 playback.

### DIFF
--- a/src/views/TrackPositionAnimation/TrackPositionAnimationTypes.ts
+++ b/src/views/TrackPositionAnimation/TrackPositionAnimationTypes.ts
@@ -35,7 +35,7 @@ export type PositionFrame = {
  * @member ymin Lowest y-value to display, in native units.
  * @member ymax Highest y-value to display, in native units.
  * @member headDirection Direction of the subject's head in the xy-plane, in radians.
- * @member realTimeReplayRate Optional, assumed 1. If set, specifies the initial frames-per-tick for playback.
+ * @member realTimeReplayRate Optional, assumed 1000/60. If set, specifies the number of milliseconds per frame to achieve real-time playback.
  */
 export type TrackAnimationStaticData = {
     type: 'TrackAnimation'

--- a/src/views/TrackPositionAnimation/TrackPositionAnimationTypes.ts
+++ b/src/views/TrackPositionAnimation/TrackPositionAnimationTypes.ts
@@ -35,7 +35,7 @@ export type PositionFrame = {
  * @member ymin Lowest y-value to display, in native units.
  * @member ymax Highest y-value to display, in native units.
  * @member headDirection Direction of the subject's head in the xy-plane, in radians.
- * @member initialReplayRate Optional, assumed 1. If set, specifies the initial frames per tick for playback.
+ * @member realTimeReplayRate Optional, assumed 1. If set, specifies the initial frames-per-tick for playback.
  */
 export type TrackAnimationStaticData = {
     type: 'TrackAnimation'
@@ -51,7 +51,7 @@ export type TrackAnimationStaticData = {
     ymin: number
     ymax: number
     headDirection?: number[]
-    initialReplayRate?: number
+    realTimeReplayRateMs?: number
 }
 
 export const isTrackAnimationStaticData = (x: any): x is TrackAnimationStaticData => {
@@ -69,7 +69,7 @@ export const isTrackAnimationStaticData = (x: any): x is TrackAnimationStaticDat
         ymin: isNumber,
         ymax: isNumber,
         headDirection: optional(isArrayOf(isNumber)),
-        initialReplayRate: optional(isNumber)
+        realTimeReplayRateMs: optional(isNumber)
     })
     if (typeMatch) {
         const candidate = x as TrackAnimationStaticData

--- a/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
+++ b/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
@@ -57,7 +57,7 @@ const initialState = makeDefaultState<PositionFrame>()
 
 const TrackPositionAnimationView: FunctionComponent<TrackPositionAnimationProps> = (props: TrackPositionAnimationProps) => {
     const { data, width, height } = props
-    const { xmin, xmax, ymin, ymax, initialReplayRate, headDirection } = data
+    const { xmin, xmax, ymin, ymax, realTimeReplayRateMs, headDirection } = data
     // Note: to expose this to other components, may wish to elevate to a full context
     const [animationState, animationStateDispatch] = React.useReducer<TPAReducer>(AnimationStateReducer, initialState)
     useEffect(() => {
@@ -69,13 +69,13 @@ const TrackPositionAnimationView: FunctionComponent<TrackPositionAnimationProps>
         })
     }, [animationStateDispatch])
     useEffect(() => {
-        if (initialReplayRate && initialReplayRate !== 0) {
+        if (realTimeReplayRateMs && realTimeReplayRateMs !== 0) {
             animationStateDispatch({
-                type: 'SET_REPLAY_RATE',
-                newRate: initialReplayRate
+                type: 'SET_BASE_MS_PER_FRAME',
+                baseMsPerFrame: realTimeReplayRateMs
             })
         }
-    })
+    }, [realTimeReplayRateMs])
 
     const drawHeight = height - controlsHeight
 
@@ -160,9 +160,9 @@ const TrackPositionAnimationView: FunctionComponent<TrackPositionAnimationProps>
             totalFrameCount={animationState.frameData.length}
             currentFrameIndex={animationState.currentFrameIndex}
             isPlaying={animationState.isPlaying}
-            playbackRate={animationState.framesPerTick}
+            playbackRate={animationState.replayMultiplier}
         />
-    }, [width, drawHeight, animationState.frameData.length, animationState.currentFrameIndex, animationState.isPlaying, animationState.framesPerTick])
+    }, [width, drawHeight, animationState.frameData.length, animationState.currentFrameIndex, animationState.isPlaying, animationState.replayMultiplier])
  
     return (
     <Fragment>

--- a/src/views/common/Animation/AnimationStateControlButtons.tsx
+++ b/src/views/common/Animation/AnimationStateControlButtons.tsx
@@ -15,7 +15,7 @@ export type AnimationStateControlButtonsProps<T> = {
     usingRateButtons?: boolean
 }
 
-const defaultPlaybackRates = [0.1, 0.25, 0.5, 1, 2, 3, 4, 5, 10 ]
+const defaultPlaybackRates = [0.1, 0.125, 0.25, 0.5, 1, 2, 3, 4, 5, 10 ]
 const PlaybackRateDropdown = <T, >(props: AnimationStateControlButtonsProps<T>) => {
     const { playbackRate, customPlaybackRates, usingRateButtons, dispatch } = props
     const playbackRates = useMemo(() => {


### PR DESCRIPTION
For review--we should discuss before merging. Note merge target is the head direction branch.

This PR adds a real-time (1:1) replay rate figure in MS, and keys the other replay rate timings off this multiplier (which defaults to 16.6-bar or 60 fps).

Example: https://www.figurl.org/f?v=http://localhost:3000&d=ipfs://bafybeiaanv2dz5gazhynganbeibd7xnkefrrcjwxetamrmcylfe3wndyju&label=example%20track%20animation

In the load script (different project so not part of this PR), we compute and include the `realTimeReplayRateMs` as follows:

```python
# timestamps = 1-dimensional numpy array of the times
vals, counts = np.unique(np.diff(timestamps), return_counts=True)
idx = np.argmax(counts)
interframe_ms = vals[idx] * 1000
data['realTimeReplayRateMs'] = interframe_ms
```
which sets the elapsed time per frame to the modal value of the observed differences between frame times in the data set.

The front-end in this PR has some debug code to report the base MS per frame (which should be removed before it is accepted) whenever the playback is paused. This confirms that the base MS per frame in the example is the expected value of 33.619-something ms.

However, note that playback is not actually real-time at this rate: empirically (timing for 10 elapsed seconds per the displayed timing in the recording) 10 seconds of playback takes about 15 seconds of real time. I expect this is due to accumulated rounding error/incompatibility between the 60-fps refresh rate for the animation callbacks and the desired frame rate--since the "time last frame was drawn" has to get reset every cycle, instead of having a frame rate seesaw, instead we just have consistent lag behind the intended frame rate so that we actually realize something like 20 FPS instead of the 29.75 intended FPS.