### PR TITLE
Sync focus time with animation

### DIFF
--- a/devel/deploy_dev.sh
+++ b/devel/deploy_dev.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-TARGET=gs://figurl/spikesortingview-6dev2
+TARGET=gs://figurl/spikesortingview-6dev3
 
 yarn build
 gsutil -m cp -R ./build/* $TARGET/

--- a/src/contexts/RecordingSelectionContext.ts
+++ b/src/contexts/RecordingSelectionContext.ts
@@ -333,6 +333,11 @@ const setFocusTime = (state: RecordingSelection, action: SetFocusTimeRecordingSe
                 const span = state.visibleTimeEndSeconds - state.visibleTimeStartSeconds
                 newState.visibleTimeStartSeconds = focusTimeSec - span / 2
                 newState.visibleTimeEndSeconds = focusTimeSec + span / 2
+                if (newState.visibleTimeEndSeconds > (state.recordingEndTimeSeconds || 0)) {
+                    const delta = (state.recordingEndTimeSeconds || 0) - newState.visibleTimeEndSeconds
+                    newState.visibleTimeStartSeconds += delta
+                    newState.visibleTimeEndSeconds += delta
+                }
                 if (newState.visibleTimeStartSeconds < (state.recordingStartTimeSeconds || 0)) {
                     const delta = (state.recordingStartTimeSeconds || 0) - newState.visibleTimeStartSeconds
                     newState.visibleTimeStartSeconds += delta

--- a/src/util/bst.ts
+++ b/src/util/bst.ts
@@ -2,52 +2,103 @@ import { useMemo } from "react"
 
 export type BstNode<T> = {
     value: T | undefined
+    baseListIndex: number | undefined
     left: BstNode<T> | undefined
     right: BstNode<T> | undefined
 }
 
-const makeBinaryTree = <T,>(items: T[]): BstNode<T> => {
+export interface ValueWithPosition<T> {
+    value: T,
+    baseListIndex: number
+}
+
+export interface BstSearchResult<T> extends ValueWithPosition<T> {
+    offBy: number
+}
+
+export type BstSearchFn<T> = (value: T, requireExact?: boolean) => BstSearchResult<T> | undefined
+export type MetricFn<T> = (a: T, b: T) => number
+
+export const makeBinaryTree = <T,>(items: ValueWithPosition<T>[]): BstNode<T> => {
     switch (items.length) {
         case 0:
             console.log(`Encountered empty array in building binary search tree: this probably shoudn't happen`)
-            return { value: undefined, left: undefined, right: undefined } as BstNode<T>
+            return { value: undefined, left: undefined, right: undefined, baseListIndex: undefined } as BstNode<T>
         case 1:
-            return { value: items[0], left: undefined, right: undefined } as BstNode<T>
+            return { value: items[0].value, left: undefined, right: undefined, baseListIndex: items[0].baseListIndex } as BstNode<T>
         case 2: // the node will have only 1 child! Let's arbitrarily make it the left one
-            return { value: items[1], left: makeBinaryTree([items[0]]), right: undefined } as BstNode<T>
+            return { value: items[1].value, left: makeBinaryTree([items[0]]), right: undefined, baseListIndex: items[1].baseListIndex } as BstNode<T>
         default:
             const split = Math.floor(items.length / 2)
             const leftChild = makeBinaryTree(items.slice(0, split))
-            const value = items[split]
+            const thisNode = items[split]
             const rightChild = makeBinaryTree(items.slice(split + 1))
-            return { value: value, left: leftChild, right: rightChild } as BstNode<T>
+            return { value: thisNode.value, baseListIndex: thisNode.baseListIndex, left: leftChild, right: rightChild } as BstNode<T>
     }
 }
 
 
-export const useBinarySearchTree = <T,>(items: T[], needsSort: boolean = false, compFn: (a: T, b: T) => number): BstNode<T> => {
+const nodeToValue = <T,>(node: BstNode<T>, difference: number): BstSearchResult<T> | undefined => {
+    if (!node || node.value === undefined || node.baseListIndex === undefined) return undefined
+    return {
+        value: node.value, baseListIndex: node.baseListIndex, offBy: difference
+    }
+}
+
+
+export const getSearchFn = <T,>(metricFn: MetricFn<T>, root: BstNode<T>): BstSearchFn<T> => {
+    return (value: T, requireExact: boolean = false) => _searchBinaryTree(value, metricFn, root, requireExact)
+}
+
+
+const _searchBinaryTree = <T,>(value: T, metricFn: MetricFn<T>, node?: BstNode<T>, requireExact: boolean = false): BstSearchResult<T> | undefined => {
+    if (!node || node.value === undefined) return undefined
+    const diff = metricFn(value, node.value)
+    if (diff === 0) return nodeToValue(node, diff)
+
+    // Negative means a sorts before b, i.e. the value is less than the node value.
+    const candidateSubtree = diff < 0 ? node.left : node.right
+    const candidateNode = _searchBinaryTree(value, metricFn, candidateSubtree, requireExact)
+
+    // candidateNode is now either a node with a match, or undefined (if we required exact and the value isn't in the BST.)
+    // If we must return exact, return the candidate.
+    // For inexact search, return the closest value, or the parent value if the child was undefined or the values tied.
+    // TODO: consider if we would rather deterministically return the lower value.
+    return requireExact
+        ? candidateNode
+        : candidateNode === undefined
+            ? nodeToValue(node, diff)
+            : Math.abs(candidateNode.offBy) < Math.abs(diff)
+                ? candidateNode
+                : nodeToValue(node, diff)
+}
+
+
+/**
+ * Hook to create a reusable binary search tree for a fixed data set.
+ * Note that no methods to extend or rebalance the tree are included, since we don't anticipate needing that
+ * use case at this time.
+ * (TODO: Could add a parameter to avoid checking sort on a pre-sorted list of data.)
+ * 
+ * @param items (Typed) list of values to place in a binary search tree.
+ * @param metricFn Appropriate comparator function for the value type.
+ * @returns Search function for fast searches of the input list.
+ */
+// export const useBinarySearchTree = <T,>(items: T[], metricFn: (a: T, b: T) => number): BstNode<T> => {
+const useBinarySearchTree = <T,>(items: T[], metricFn: MetricFn<T>): BstSearchFn<T> => {
     return useMemo(() => {
-        if (needsSort) {
-            items.sort((a, b) => compFn(a, b))
-        }
-        const sortedArray = needsSort ? items.sort() : items
-        const sorted = sortedArray.every((item, index, array) => {
-            return index === 0 || (item > array[index - 1])
+        console.log(`Building BST.`)
+        const labeledItems = items.map((item, index) => { return { value: item, baseListIndex: index } })
+        const sorted = labeledItems.every((item, index, array) => {
+            return index === 0 || metricFn(item.value, array[index - 1].value) >= 0
         })
         if (!sorted) {
-            throw new Error("Timestamp array not sorted.")
+            labeledItems.sort((a, b) => metricFn(a.value, b.value))
         }
 
-        return makeBinaryTree(items)
-    }, [items])
+        const root = makeBinaryTree(labeledItems)
+        return getSearchFn(metricFn, root)
+    }, [items, metricFn])
 }
 
-
-export const searchBinaryTree = <T,>(value: T, node: BstNode<T>, compFn: (a: T, b: T) => number, requireExact: boolean = false) => {
-    // TODO: NEED TO REPORT THE ACTUAL INDEX? (Maybe for some applications)
-    if (!node || node.value === undefined) return undefined
-    const diff = compFn(value, node.value)
-    if (diff === 0) return value
-
-}
-
+export default useBinarySearchTree

--- a/src/util/bst.ts
+++ b/src/util/bst.ts
@@ -1,0 +1,53 @@
+import { useMemo } from "react"
+
+export type BstNode<T> = {
+    value: T | undefined
+    left: BstNode<T> | undefined
+    right: BstNode<T> | undefined
+}
+
+const makeBinaryTree = <T,>(items: T[]): BstNode<T> => {
+    switch (items.length) {
+        case 0:
+            console.log(`Encountered empty array in building binary search tree: this probably shoudn't happen`)
+            return { value: undefined, left: undefined, right: undefined } as BstNode<T>
+        case 1:
+            return { value: items[0], left: undefined, right: undefined } as BstNode<T>
+        case 2: // the node will have only 1 child! Let's arbitrarily make it the left one
+            return { value: items[1], left: makeBinaryTree([items[0]]), right: undefined } as BstNode<T>
+        default:
+            const split = Math.floor(items.length / 2)
+            const leftChild = makeBinaryTree(items.slice(0, split))
+            const value = items[split]
+            const rightChild = makeBinaryTree(items.slice(split + 1))
+            return { value: value, left: leftChild, right: rightChild } as BstNode<T>
+    }
+}
+
+
+export const useBinarySearchTree = <T,>(items: T[], needsSort: boolean = false, compFn: (a: T, b: T) => number): BstNode<T> => {
+    return useMemo(() => {
+        if (needsSort) {
+            items.sort((a, b) => compFn(a, b))
+        }
+        const sortedArray = needsSort ? items.sort() : items
+        const sorted = sortedArray.every((item, index, array) => {
+            return index === 0 || (item > array[index - 1])
+        })
+        if (!sorted) {
+            throw new Error("Timestamp array not sorted.")
+        }
+
+        return makeBinaryTree(items)
+    }, [items])
+}
+
+
+export const searchBinaryTree = <T,>(value: T, node: BstNode<T>, compFn: (a: T, b: T) => number, requireExact: boolean = false) => {
+    // TODO: NEED TO REPORT THE ACTUAL INDEX? (Maybe for some applications)
+    if (!node || node.value === undefined) return undefined
+    const diff = compFn(value, node.value)
+    if (diff === 0) return value
+
+}
+

--- a/src/util/bst.ts
+++ b/src/util/bst.ts
@@ -73,6 +73,10 @@ const _searchBinaryTree = <T,>(value: T, metricFn: MetricFn<T>, node?: BstNode<T
                 : nodeToValue(node, diff)
 }
 
+// TODO: This is all potentially unnecessary--if we don't support inserts, we don't need an actual tree; we could
+// just use a binary search pattern on a sorted array.
+// Do note though that we probably don't have O(1) random access to elements of a javascript array, so
+// that might be a reason to still do this.
 
 /**
  * Hook to create a reusable binary search tree for a fixed data set.
@@ -87,7 +91,6 @@ const _searchBinaryTree = <T,>(value: T, metricFn: MetricFn<T>, node?: BstNode<T
 // export const useBinarySearchTree = <T,>(items: T[], metricFn: (a: T, b: T) => number): BstNode<T> => {
 const useBinarySearchTree = <T,>(items: T[], metricFn: MetricFn<T>): BstSearchFn<T> => {
     return useMemo(() => {
-        console.log(`Building BST.`)
         const labeledItems = items.map((item, index) => { return { value: item, baseListIndex: index } })
         const sorted = labeledItems.every((item, index, array) => {
             return index === 0 || metricFn(item.value, array[index - 1].value) >= 0

--- a/src/views/TrackPositionAnimation/TPATimeSyncLogic.tsx
+++ b/src/views/TrackPositionAnimation/TPATimeSyncLogic.tsx
@@ -16,7 +16,7 @@ type TimeLookupFn = (time: number) => BstSearchResult<number> | undefined
 
 export const matchFocusToFrame = (animationState: AnimationState<PositionFrame>, focusTime: number | undefined, setTimeFocus: (time: number) => void) => {
     const epsilon = 0.05
-    const currentTime = animationState.frameData[animationState.currentFrameIndex].timestamp
+    const currentTime = animationState?.frameData[animationState?.currentFrameIndex]?.timestamp
     if (!currentTime || !focusTime) return
     if (Math.abs(focusTime - currentTime) < epsilon) return
     setTimeFocus(currentTime)
@@ -25,7 +25,7 @@ export const matchFocusToFrame = (animationState: AnimationState<PositionFrame>,
 export const matchFrameToFocus = (focusTime: number | undefined, findNearestTime: TimeLookupFn, animationState: AnimationState<PositionFrame>, animationStateDispatch: React.Dispatch<AnimationStateAction<PositionFrame>>) => {
     const focusIndex = focusTime
         ? findNearestTime(focusTime)?.baseListIndex ?? animationState.currentFrameIndex
-        : animationState.currentFrameIndex
+        : animationState?.currentFrameIndex
     if (focusIndex !== animationState.currentFrameIndex) {
         animationStateDispatch({
             type: 'SET_CURRENT_FRAME',
@@ -35,7 +35,7 @@ export const matchFrameToFocus = (focusTime: number | undefined, findNearestTime
 }
 
 const useTimeLookupFn = (animationState: AnimationState<PositionFrame>) => {
-    const realizedTimestamps = useMemo(() => animationState.frameData.map(d => d.timestamp || -1), [animationState.frameData])
+    const realizedTimestamps = useMemo(() => animationState.frameData.map(d => d ? d.timestamp || -1 : -1), [animationState.frameData])
     const timeSearchFn = useBinarySearchTree<number>(realizedTimestamps, timeComparison) // do not use an anonymous fn here--results in constant refreshes
     const findNearestTime = useCallback((time: number) => {
         return snapTimeToGrid(time, timeSearchFn)

--- a/src/views/TrackPositionAnimation/TPATimeSyncLogic.tsx
+++ b/src/views/TrackPositionAnimation/TPATimeSyncLogic.tsx
@@ -14,24 +14,23 @@ const timeComparison = (a: number, b: number) => a - b
 
 type TimeLookupFn = (time: number) => BstSearchResult<number> | undefined
 
-export const matchFocusToFrame = (animationState: AnimationState<PositionFrame>, focusTime: number | undefined, setTimeFocus: (time: number) => void) => {
-    const epsilon = 0.05
-    const currentTime = animationState?.frameData[animationState?.currentFrameIndex]?.timestamp
-    if (!currentTime || !focusTime) return
-    if (Math.abs(focusTime - currentTime) < epsilon) return
-    setTimeFocus(currentTime)
+export const matchFocusToFrame = (animationCurrentTime: number | undefined, setTimeFocus: (time: number, o: {autoScrollVisibleTimeRange?: boolean}) => void) => {
+    // const epsilon = 0.05
+    const currentTime = animationCurrentTime
+    if (currentTime === undefined) return
+    // don't let this function depend on focusTime
+    // if (Math.abs(focusTime - currentTime) < epsilon) return
+    setTimeFocus(currentTime, {autoScrollVisibleTimeRange: true})
 }
 
-export const matchFrameToFocus = (focusTime: number | undefined, findNearestTime: TimeLookupFn, animationState: AnimationState<PositionFrame>, animationStateDispatch: React.Dispatch<AnimationStateAction<PositionFrame>>) => {
-    const focusIndex = focusTime
-        ? findNearestTime(focusTime)?.baseListIndex ?? animationState.currentFrameIndex
-        : animationState?.currentFrameIndex
-    if (focusIndex !== animationState.currentFrameIndex) {
-        animationStateDispatch({
-            type: 'SET_CURRENT_FRAME',
-            newIndex: focusIndex
-        })
-    }
+export const matchFrameToFocus = (focusTime: number | undefined, findNearestTime: TimeLookupFn, animationStateDispatch: React.Dispatch<AnimationStateAction<PositionFrame>>) => {
+    if (focusTime === undefined) return
+    const focusIndex = findNearestTime(focusTime)?.baseListIndex
+    if (focusIndex === undefined) return
+    animationStateDispatch({
+        type: 'SET_CURRENT_FRAME',
+        newIndex: focusIndex
+    })
 }
 
 const useTimeLookupFn = (animationState: AnimationState<PositionFrame>) => {

--- a/src/views/TrackPositionAnimation/TPATimeSyncLogic.tsx
+++ b/src/views/TrackPositionAnimation/TPATimeSyncLogic.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useMemo } from "react"
+import useBinarySearchTree, { BstSearchFn, BstSearchResult } from "util/bst"
+import { AnimationState, AnimationStateAction } from "views/common/Animation/AnimationStateReducer"
+import { PositionFrame } from "./TrackPositionAnimationTypes"
+
+
+
+const snapTimeToGrid = (time: number, searchFn: BstSearchFn<number>) => {
+    const nearestTime = searchFn(time)
+    return nearestTime
+}
+
+const timeComparison = (a: number, b: number) => a - b
+
+type TimeLookupFn = (time: number) => BstSearchResult<number> | undefined
+
+export const matchFocusToFrame = (animationState: AnimationState<PositionFrame>, focusTime: number | undefined, setTimeFocus: (time: number) => void) => {
+    const epsilon = 0.05
+    const currentTime = animationState.frameData[animationState.currentFrameIndex].timestamp
+    if (!currentTime || !focusTime) return
+    if (Math.abs(focusTime - currentTime) < epsilon) return
+    setTimeFocus(currentTime)
+}
+
+export const matchFrameToFocus = (focusTime: number | undefined, findNearestTime: TimeLookupFn, animationState: AnimationState<PositionFrame>, animationStateDispatch: React.Dispatch<AnimationStateAction<PositionFrame>>) => {
+    const focusIndex = focusTime
+        ? findNearestTime(focusTime)?.baseListIndex ?? animationState.currentFrameIndex
+        : animationState.currentFrameIndex
+    if (focusIndex !== animationState.currentFrameIndex) {
+        animationStateDispatch({
+            type: 'SET_CURRENT_FRAME',
+            newIndex: focusIndex
+        })
+    }
+}
+
+const useTimeLookupFn = (animationState: AnimationState<PositionFrame>) => {
+    const realizedTimestamps = useMemo(() => animationState.frameData.map(d => d.timestamp || -1), [animationState.frameData])
+    const timeSearchFn = useBinarySearchTree<number>(realizedTimestamps, timeComparison) // do not use an anonymous fn here--results in constant refreshes
+    const findNearestTime = useCallback((time: number) => {
+        return snapTimeToGrid(time, timeSearchFn)
+    }, [timeSearchFn])
+
+    return findNearestTime
+}
+
+export default useTimeLookupFn

--- a/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
+++ b/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
@@ -171,8 +171,15 @@ const TrackPositionAnimationView: FunctionComponent<TrackPositionAnimationProps>
 
     const { focusTime, setTimeFocus } = useTimeFocus()  // state imported from recording context
     const findNearestTime = useTimeLookupFn(animationState)
-    useEffect(() => matchFrameToFocus(focusTime, findNearestTime, animationState, animationStateDispatch), [focusTime])
-    useEffect(() => matchFocusToFrame(animationState, focusTime, setTimeFocus), [animationState.isPlaying])
+    const animationCurrentTime = animationState?.frameData[animationState?.currentFrameIndex]?.timestamp
+    useEffect(() => {
+        matchFrameToFocus(focusTime, findNearestTime, animationStateDispatch)
+    }, [focusTime, findNearestTime])
+    
+    useEffect(() => {
+        if (animationState.isPlaying) return
+        matchFocusToFrame(animationCurrentTime, setTimeFocus)
+    }, [animationCurrentTime, setTimeFocus, animationState.isPlaying])
 
     const currentProbabilityFrame = useMemo(() => {
         const linearFrame = dataFrames[animationState.currentFrameIndex].decodedPositionFrame

--- a/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
+++ b/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
@@ -133,8 +133,14 @@ const useDrawingSpace = (width: number, drawHeight: number, xmax: number, xmin: 
     return { finalMargins, transform }
 }
 
+
 type TPAReducer = React.Reducer<AnimationState<PositionFrame>, AnimationStateAction<PositionFrame>>
 const initialState = makeDefaultState<PositionFrame>()
+
+const snapTimeToGrid = (time: number, timestampStart: number | undefined, timestamps: number[]) => {
+    const relativeTime = timestampStart ? time - timestampStart : time
+
+}
 
 const TrackPositionAnimationView: FunctionComponent<TrackPositionAnimationProps> = (props: TrackPositionAnimationProps) => {
     const { data, width, height } = props

--- a/src/views/common/Animation/AnimationStateReducer.tsx
+++ b/src/views/common/Animation/AnimationStateReducer.tsx
@@ -230,6 +230,11 @@ const setFrame = <T, >(s: AnimationState<T>, a: AnimationStateSetCurrentFrameAct
         console.warn(`Attempt to set playback index to negative value ${newIndex}. No-op.`)
         return s
     }
+    if (newIndex === s.currentFrameIndex) {
+        // attempt to set index to current frame index--no-op.
+        // Return the input state to avoid causing rerenders anywhere.
+        return s
+    }
     if (0 < newIndex && newIndex < 1) {
         const i = Math.floor(s.frameData.length * newIndex)
         s.currentFrameIndex = i

--- a/src/views/common/Animation/AnimationStateReducer.tsx
+++ b/src/views/common/Animation/AnimationStateReducer.tsx
@@ -162,19 +162,21 @@ const AnimationStateReducer = <T, >(s: AnimationState<T>, a: AnimationStateActio
 // It's not actually clear that this ever did anything useful.
 // TODO: Deprecated. Remove this function (& references to it) after Sep 2022
 // if the widget's behavior remains normal.
-const refreshAnimationCycle = (s: AnimationState<any>) => {
-    if (s.pendingFrameCode === undefined) {
-        return
-    }
-    window.cancelAnimationFrame(s.pendingFrameCode)
-    if (s.animationDispatchFn === undefined) {
-        console.warn('Animation callback unset.')
-        return
-    }
-    if (s.isPlaying) {
-        s.pendingFrameCode = window.requestAnimationFrame(s.animationDispatchFn)
-    }
-}
+// jfm says: All references to this function have been commented out,
+// so I'm commenting out this function so it doesn't create a linter warning
+// const refreshAnimationCycle = (s: AnimationState<any>) => {
+//     if (s.pendingFrameCode === undefined) {
+//         return
+//     }
+//     window.cancelAnimationFrame(s.pendingFrameCode)
+//     if (s.animationDispatchFn === undefined) {
+//         console.warn('Animation callback unset.')
+//         return
+//     }
+//     if (s.isPlaying) {
+//         s.pendingFrameCode = window.requestAnimationFrame(s.animationDispatchFn)
+//     }
+// }
 
 
 const updateFrames = <T, >(s: AnimationState<T>, a: AnimationStateUpdateFrameDataAction<T>): AnimationState<T> => {


### PR DESCRIPTION
This PR includes some logic and links to make the `TrackPositionAnimation` aware of the context-global focus time from the `RecordingSelectionContext` object.

The implemented behavior is as follows:

- A click in a view that sets the focus time (e.g. the raster plot view) will update the focus time. The new focus time will be communicated to the animation, which finds the frame with the closest time code and sets that as the currently active frame. Playback (if in progress) will continue uninterrupted from that point.
- The time represented by the currently active playback frame will be set as the focus time in the context whenever playback starts or stops. This allows other views to sync to the currently visible animation frame.

In a future version, I will probably alter the condition for syncing from the animation to the other views, so that they can scroll in real-time--this will probably involve logic in the default `TimeScrollView` to recenter the recording viewing window if the focus time is set outside the visible window, but that needs more feature design before we can implement it.