### PR TITLE
animation time sync updates

### DIFF
--- a/src/contexts/RecordingSelectionContext.ts
+++ b/src/contexts/RecordingSelectionContext.ts
@@ -333,6 +333,11 @@ const setFocusTime = (state: RecordingSelection, action: SetFocusTimeRecordingSe
                 const span = state.visibleTimeEndSeconds - state.visibleTimeStartSeconds
                 newState.visibleTimeStartSeconds = focusTimeSec - span / 2
                 newState.visibleTimeEndSeconds = focusTimeSec + span / 2
+                if (newState.visibleTimeEndSeconds > (state.recordingEndTimeSeconds || 0)) {
+                    const delta = (state.recordingEndTimeSeconds || 0) - newState.visibleTimeEndSeconds
+                    newState.visibleTimeStartSeconds += delta
+                    newState.visibleTimeEndSeconds += delta
+                }
                 if (newState.visibleTimeStartSeconds < (state.recordingStartTimeSeconds || 0)) {
                     const delta = (state.recordingStartTimeSeconds || 0) - newState.visibleTimeStartSeconds
                     newState.visibleTimeStartSeconds += delta

--- a/src/views/TrackPositionAnimation/TPATimeSyncLogic.tsx
+++ b/src/views/TrackPositionAnimation/TPATimeSyncLogic.tsx
@@ -14,24 +14,23 @@ const timeComparison = (a: number, b: number) => a - b
 
 type TimeLookupFn = (time: number) => BstSearchResult<number> | undefined
 
-export const matchFocusToFrame = (animationState: AnimationState<PositionFrame>, focusTime: number | undefined, setTimeFocus: (time: number) => void) => {
-    const epsilon = 0.05
-    const currentTime = animationState?.frameData[animationState?.currentFrameIndex]?.timestamp
-    if (!currentTime || !focusTime) return
-    if (Math.abs(focusTime - currentTime) < epsilon) return
-    setTimeFocus(currentTime)
+export const matchFocusToFrame = (animationCurrentTime: number | undefined, setTimeFocus: (time: number, o: {autoScrollVisibleTimeRange?: boolean}) => void) => {
+    // const epsilon = 0.05
+    const currentTime = animationCurrentTime
+    if (currentTime === undefined) return
+    // don't let this function depend on focusTime
+    // if (Math.abs(focusTime - currentTime) < epsilon) return
+    setTimeFocus(currentTime, {autoScrollVisibleTimeRange: true})
 }
 
-export const matchFrameToFocus = (focusTime: number | undefined, findNearestTime: TimeLookupFn, animationState: AnimationState<PositionFrame>, animationStateDispatch: React.Dispatch<AnimationStateAction<PositionFrame>>) => {
-    const focusIndex = focusTime
-        ? findNearestTime(focusTime)?.baseListIndex ?? animationState.currentFrameIndex
-        : animationState?.currentFrameIndex
-    if (focusIndex !== animationState.currentFrameIndex) {
-        animationStateDispatch({
-            type: 'SET_CURRENT_FRAME',
-            newIndex: focusIndex
-        })
-    }
+export const matchFrameToFocus = (focusTime: number | undefined, findNearestTime: TimeLookupFn, animationStateDispatch: React.Dispatch<AnimationStateAction<PositionFrame>>) => {
+    if (focusTime === undefined) return
+    const focusIndex = findNearestTime(focusTime)?.baseListIndex
+    if (focusIndex === undefined) return
+    animationStateDispatch({
+        type: 'SET_CURRENT_FRAME',
+        newIndex: focusIndex
+    })
 }
 
 const useTimeLookupFn = (animationState: AnimationState<PositionFrame>) => {

--- a/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
+++ b/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
@@ -171,8 +171,15 @@ const TrackPositionAnimationView: FunctionComponent<TrackPositionAnimationProps>
 
     const { focusTime, setTimeFocus } = useTimeFocus()  // state imported from recording context
     const findNearestTime = useTimeLookupFn(animationState)
-    useEffect(() => matchFrameToFocus(focusTime, findNearestTime, animationState, animationStateDispatch), [focusTime])
-    useEffect(() => matchFocusToFrame(animationState, focusTime, setTimeFocus), [animationState.isPlaying])
+    const animationCurrentTime = animationState?.frameData[animationState?.currentFrameIndex]?.timestamp
+    useEffect(() => {
+        matchFrameToFocus(focusTime, findNearestTime, animationStateDispatch)
+    }, [focusTime, findNearestTime])
+    
+    useEffect(() => {
+        if (animationState.isPlaying) return
+        matchFocusToFrame(animationCurrentTime, setTimeFocus)
+    }, [animationCurrentTime, setTimeFocus, animationState.isPlaying])
 
     const currentProbabilityFrame = useMemo(() => {
         const linearFrame = dataFrames[animationState.currentFrameIndex].decodedPositionFrame

--- a/src/views/common/Animation/AnimationStateReducer.tsx
+++ b/src/views/common/Animation/AnimationStateReducer.tsx
@@ -162,19 +162,21 @@ const AnimationStateReducer = <T, >(s: AnimationState<T>, a: AnimationStateActio
 // It's not actually clear that this ever did anything useful.
 // TODO: Deprecated. Remove this function (& references to it) after Sep 2022
 // if the widget's behavior remains normal.
-const refreshAnimationCycle = (s: AnimationState<any>) => {
-    if (s.pendingFrameCode === undefined) {
-        return
-    }
-    window.cancelAnimationFrame(s.pendingFrameCode)
-    if (s.animationDispatchFn === undefined) {
-        console.warn('Animation callback unset.')
-        return
-    }
-    if (s.isPlaying) {
-        s.pendingFrameCode = window.requestAnimationFrame(s.animationDispatchFn)
-    }
-}
+// jfm says: All references to this function have been commented out,
+// so I'm commenting out this function so it doesn't create a linter warning
+// const refreshAnimationCycle = (s: AnimationState<any>) => {
+//     if (s.pendingFrameCode === undefined) {
+//         return
+//     }
+//     window.cancelAnimationFrame(s.pendingFrameCode)
+//     if (s.animationDispatchFn === undefined) {
+//         console.warn('Animation callback unset.')
+//         return
+//     }
+//     if (s.isPlaying) {
+//         s.pendingFrameCode = window.requestAnimationFrame(s.animationDispatchFn)
+//     }
+// }
 
 
 const updateFrames = <T, >(s: AnimationState<T>, a: AnimationStateUpdateFrameDataAction<T>): AnimationState<T> => {


### PR DESCRIPTION
As we discussed.

This PR does 2 things
(1) Adjusts the useEffect hooks to sync the focus time state and the current animation frame. I noticed that some of the dependencies were not included and the linter was complaining. When I added those, the gui went into an infinite cycle between previous and current state. I then adjusted the logic to remove unnecessary dependencies and avoid the infinite cycle. However, as we discussed, this may be bypassing some checks that prevent unnecessary rerenders. I'm not sure if that's the case. We should investigate. I will look into finding or creating a simplified example of syncing the state between two components.

(2) Added an option in setFocusTime to automatically scroll the visible time range so that the new focus time is visible. Turned this option on for syncing between animation and focus time.