### PR TITLE
Time offset

### DIFF
--- a/src/contexts/RecordingSelectionContext.ts
+++ b/src/contexts/RecordingSelectionContext.ts
@@ -61,24 +61,24 @@ export const useRecordingSelection = () => {
     return c
 }
 
-export const useRecordingSelectionTimeInitialization = (start: number, end: number) => {
+export const useRecordingSelectionTimeInitialization = (start: number, end: number, timeOffset: number=0) => {
     const { recordingSelection, recordingSelectionDispatch } = useRecordingSelection()
 
     useEffect(() => {
-        if (recordingSelection.recordingStartTimeSeconds === start &&
-            recordingSelection.recordingEndTimeSeconds === end) return
+        if (recordingSelection.recordingStartTimeSeconds === start + timeOffset &&
+            recordingSelection.recordingEndTimeSeconds === end + timeOffset) return
 
         recordingSelectionDispatch({
             type: 'initializeRecordingSelectionTimes',
-            recordingStartSec: start,
-            recordingEndSec: end
+            recordingStartSec: start + timeOffset,
+            recordingEndSec: end + timeOffset
         })
-    }, [recordingSelection.recordingStartTimeSeconds, recordingSelection.recordingEndTimeSeconds, recordingSelectionDispatch, start, end])
+    }, [recordingSelection.recordingStartTimeSeconds, recordingSelection.recordingEndTimeSeconds, recordingSelectionDispatch, start, end, timeOffset])
 }
 
 export type ZoomDirection = 'in' | 'out'
 export type PanDirection = 'forward' | 'back'
-export const useTimeRange = () => {
+export const useTimeRange = (timestampOffset=0) => {
     const {recordingSelection, recordingSelectionDispatch} = useRecordingSelection()
     if (recordingSelection.visibleTimeEndSeconds === undefined || recordingSelection.visibleTimeStartSeconds === undefined) {
         console.warn('WARNING: useTimeRange() with uninitialized recording selection state. Time ranges replaced with MIN_SAFE_INTEGER.')
@@ -102,8 +102,8 @@ export const useTimeRange = () => {
         })
     }, [recordingSelectionDispatch])
     return {
-        visibleTimeStartSeconds: recordingSelection.visibleTimeStartSeconds,
-        visibleTimeEndSeconds: recordingSelection.visibleTimeEndSeconds,
+        visibleTimeStartSeconds: recordingSelection.visibleTimeStartSeconds !== undefined ? recordingSelection.visibleTimeStartSeconds - timestampOffset : undefined,
+        visibleTimeEndSeconds: recordingSelection.visibleTimeEndSeconds !== undefined ? recordingSelection.visibleTimeEndSeconds - timestampOffset : undefined,
         zoomRecordingSelection,
         panRecordingSelection,
         panRecordingSelectionDeltaT

--- a/src/views/MountainLayout/MountainLayoutView.tsx
+++ b/src/views/MountainLayout/MountainLayoutView.tsx
@@ -73,7 +73,7 @@ const MountainLayoutView: FunctionComponent<Props> = ({data, hideCurationControl
             return
         }
         ;(async () => {
-            const a = await getMutable(`@sortingview/@sortingCurationAuthorizedUsers/${data.sortingCurationUri}`)
+            const a = await getMutable(`@sortingview/@sortingCurationAuthorizedUsers/${feedIdForUri(data.sortingCurationUri || '')}`)
             if (!a) return
             const authorizedUsers = JSON.parse(a)
             if (authorizedUsers.includes(userId)) {
@@ -89,6 +89,10 @@ const MountainLayoutView: FunctionComponent<Props> = ({data, hideCurationControl
         )
     }
     else return content
+}
+
+export const feedIdForUri = (uri: string) => {
+    return uri.split('/')[2] || 'invalid-feed-uri'
 }
 
 export default MountainLayoutView

--- a/src/views/MountainLayout/MountainLayoutView.tsx
+++ b/src/views/MountainLayout/MountainLayoutView.tsx
@@ -73,7 +73,7 @@ const MountainLayoutView: FunctionComponent<Props> = ({data, hideCurationControl
             return
         }
         ;(async () => {
-            const a = await getMutable(`sortingview/sortingCurationAuthorizedUsers/${data.sortingCurationUri}`)
+            const a = await getMutable(`@sortingview/@sortingCurationAuthorizedUsers/${data.sortingCurationUri}`)
             if (!a) return
             const authorizedUsers = JSON.parse(a)
             if (authorizedUsers.includes(userId)) {

--- a/src/views/PositionPlot/PositionPlotViewData.ts
+++ b/src/views/PositionPlot/PositionPlotViewData.ts
@@ -1,8 +1,9 @@
 import { validateObject } from "figurl"
-import { isArrayOf, isBoolean, isEqualTo, isString, optional } from "figurl/viewInterface/validateObject"
+import { isArrayOf, isBoolean, isEqualTo, isNumber, isString, optional } from "figurl/viewInterface/validateObject"
 
 export type PositionPlotViewData = {
     type: 'PositionPlot'
+    timeOffset?: number
     timestamps: number[]
     positions: number[][]
     dimensionLabels: string[]
@@ -12,6 +13,7 @@ export type PositionPlotViewData = {
 export const isPositionPlotViewData = (x: any): x is PositionPlotViewData => {
     return validateObject(x, {
         type: isEqualTo('PositionPlot'),
+        timeOffset: optional(isNumber),
         timestamps: () => (true),
         positions: () => (true),
         dimensionLabels: isArrayOf(isString),

--- a/src/views/SortingLayout/SortingLayoutView.tsx
+++ b/src/views/SortingLayout/SortingLayoutView.tsx
@@ -7,6 +7,7 @@ import getFileData from 'figurl/getFileData';
 import getMutable from 'figurl/getMutable';
 import { useUrlState } from 'figurl/UrlStateContext';
 import { FunctionComponent, useCallback, useEffect, useReducer, useState } from 'react';
+import { feedIdForUri } from 'views/MountainLayout/MountainLayoutView';
 import LayoutItemView from './LayoutItemView';
 import { SortingLayoutViewData } from './SortingLayoutViewData';
 
@@ -73,7 +74,7 @@ const SortingLayoutView: FunctionComponent<Props> = ({data, width, height}) => {
             return
         }
         ;(async () => {
-            const a = await getMutable(`@sortingview/@sortingCurationAuthorizedUsers/${data.sortingCurationUri}`)
+            const a = await getMutable(`@sortingview/@sortingCurationAuthorizedUsers/${feedIdForUri(data.sortingCurationUri || '')}`)
             if (!a) return
             const authorizedUsers = JSON.parse(a)
             if (authorizedUsers.includes(userId)) {

--- a/src/views/SortingLayout/SortingLayoutView.tsx
+++ b/src/views/SortingLayout/SortingLayoutView.tsx
@@ -73,7 +73,7 @@ const SortingLayoutView: FunctionComponent<Props> = ({data, width, height}) => {
             return
         }
         ;(async () => {
-            const a = await getMutable(`sortingview/sortingCurationAuthorizedUsers/${data.sortingCurationUri}`)
+            const a = await getMutable(`@sortingview/@sortingCurationAuthorizedUsers/${data.sortingCurationUri}`)
             if (!a) return
             const authorizedUsers = JSON.parse(a)
             if (authorizedUsers.includes(userId)) {

--- a/src/views/common/TimeScrollView/YAxisTicks.tsx
+++ b/src/views/common/TimeScrollView/YAxisTicks.tsx
@@ -43,10 +43,10 @@ const fitGridLines = (minGridLines: number, maxGridLines: number, range: number)
             if (fit > minGridLines && fit < maxGridLines) {
                 results.push({step: s, scale: scale})
             }
-            // this means the step size is too big. This shouldn't really happen without finding an acceptable step size first,
-            // but we'll check for it later just in case.
-            if (fit < minGridLines) { return {step: -1, scale: -1} }
-            results.push({step: 0, scale: 0})
+            // // this means the step size is too big. This shouldn't really happen without finding an acceptable step size first,
+            // // but we'll check for it later just in case.
+            // if (fit < minGridLines) { return {step: -1, scale: -1} }
+            // results.push({step: 0, scale: 0})
         }
         const a = results.find(r => r.step > 0)
         if (a) return a


### PR DESCRIPTION
@jsoules this is a bit tricky so I think we should chat about it in person.

My goal was to allow timeOffset to be passed into PositionPlot. The timestamps would then be relative to this offset, starting with timestamp 0.

I wanted to make minimal changes to code, and avoid floating point overflow. Thus, from the perspective of the position plot view, there is no time offset. But it is added as a parameter to two hooks: `useRecordingSelectionTimeInitialization` and `useTimeRange`. The other modifications to PositionPlotView are not real changes (just removing the `data.` prefix to the props)