### PR TITLE
Implement highest-probability marker dot with styling.

### DIFF
--- a/devel/deploy_dev.sh
+++ b/devel/deploy_dev.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-TARGET=gs://figurl/spikesortingview-8dev
+TARGET=gs://figurl/spikesortingview-8devb
 
 yarn build
 gsutil -m cp -R ./build/* $TARGET/

--- a/src/views/TrackPositionAnimation/TPADecodedPositionLayer.tsx
+++ b/src/views/TrackPositionAnimation/TPADecodedPositionLayer.tsx
@@ -27,8 +27,8 @@ type PeakPositionStyling = {
 }
 
 export const defaultPeakPositionStyling: PeakPositionStyling = {
-    dotRadius: 7,
-    dotRgb: 'rgb(54, 156, 0)',
+    dotRadius: 10,
+    dotRgb: 'rgb(79, 227, 0)',
     drawPeakDot: true
 }
 

--- a/src/views/TrackPositionAnimation/TPADecodedPositionLayer.tsx
+++ b/src/views/TrackPositionAnimation/TPADecodedPositionLayer.tsx
@@ -77,8 +77,6 @@ const draw = (context: CanvasRenderingContext2D, props: DecodeFrameProps, colorM
     // TODO: Test efficiency. It may be preferable to order by intensity to avoid changing styles (though current performance is fine).
     // TODO: Test whether we can expand the regions being drawn to create a smoother effect.
     // TODO: Maybe a useful form of preprocessing would convert the scalar value to the styles and then sort by those keys?
-    let maxValue = values[0]
-    let maxIndex = 0
     values.forEach((v, i) => {
         const style = stylesMap[colorMap || 'base'][v]
         context.beginPath()
@@ -88,10 +86,6 @@ const draw = (context: CanvasRenderingContext2D, props: DecodeFrameProps, colorM
         context.rect(r[0], r[1], r[2], r[3])
         context.stroke()
         context.fill()
-        if (v > maxValue) {
-            maxValue = v
-            maxIndex = i
-        }
     })
 
     // TODO: Suppress drawing if peak dot is in the same bin as the animal's actual position?

--- a/src/views/TrackPositionAnimation/TPADecodedPositionLayer.tsx
+++ b/src/views/TrackPositionAnimation/TPADecodedPositionLayer.tsx
@@ -17,6 +17,19 @@ export type DecodeLayerProps = {
 
 type DecodeFrameProps = {
     frame: DecodedPositionFramePx | undefined
+    peakCenterPx?: number[] // [x, y] pixel location of the center of the bin with highest probability (lowest linear number breaks ties)
+}
+
+type PeakPositionStyling = {
+    dotRadius?: number,
+    dotRgb?: string,
+    drawPeakDot?: boolean
+}
+
+export const defaultPeakPositionStyling: PeakPositionStyling = {
+    dotRadius: 7,
+    dotRgb: 'rgb(54, 156, 0)',
+    drawPeakDot: true
 }
 
 export type ValidColorMap =  'inferno' | 'magma' | 'plasma' | 'viridis'
@@ -39,16 +52,33 @@ const stylesMap = {
     'base': valuesRange.map((i) => `rgba(${baseRed}, ${baseBlue}, ${baseGreen}, ${i/5})`)
 }
 
-const draw = (context: CanvasRenderingContext2D, props: DecodeFrameProps, colorMap?: ValidColorMap) => {
-    const { frame } = props
+const drawPeakDot = (context: CanvasRenderingContext2D, peakCenterPx: number[], peakStyling?: PeakPositionStyling) => {
+    const style = { ...defaultPeakPositionStyling, ...peakStyling }
+    if (style.dotRgb === undefined || style.dotRadius === undefined || style.dotRadius < 1 || !style.drawPeakDot) {
+        console.warn(`Attempt to draw peak-probability dot with invalid settings -- no-op`)
+        return
+    }
+    const [x, y] = [...peakCenterPx]
+
+    context.fillStyle = style.dotRgb ?? defaultPeakPositionStyling.dotRgb
+    context.beginPath()
+    context.arc(x, y, style.dotRadius, 0, 2 * Math.PI)
+    context.fill()
+}
+
+const draw = (context: CanvasRenderingContext2D, props: DecodeFrameProps, colorMap?: ValidColorMap, peakStyling?: PeakPositionStyling) => {
+    const { frame, peakCenterPx } = props
     if (!frame) return
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
 
     const { locationRectsPx: bins, values } = frame
+    if (values.length === 0) return
+
     // TODO: Test efficiency. It may be preferable to order by intensity to avoid changing styles (though current performance is fine).
     // TODO: Test whether we can expand the regions being drawn to create a smoother effect.
     // TODO: Maybe a useful form of preprocessing would convert the scalar value to the styles and then sort by those keys?
-
+    let maxValue = values[0]
+    let maxIndex = 0
     values.forEach((v, i) => {
         const style = stylesMap[colorMap || 'base'][v]
         context.beginPath()
@@ -58,11 +88,19 @@ const draw = (context: CanvasRenderingContext2D, props: DecodeFrameProps, colorM
         context.rect(r[0], r[1], r[2], r[3])
         context.stroke()
         context.fill()
+        if (v > maxValue) {
+            maxValue = v
+            maxIndex = i
+        }
     })
+
+    // TODO: Suppress drawing if peak dot is in the same bin as the animal's actual position?
+    if (peakStyling && !peakStyling.drawPeakDot) return
+    peakCenterPx && drawPeakDot(context, peakCenterPx, peakStyling)
 }
 
-export const useConfiguredPositionDrawFunction = (colorMap?: ValidColorMap) => {
-    return useCallback((context: CanvasRenderingContext2D, props: DecodeFrameProps) => draw(context, props, colorMap), [colorMap])
+export const useConfiguredDecodedPositionDrawFunction = (colorMap?: ValidColorMap, peakStyling?: PeakPositionStyling) => {
+    return useCallback((context: CanvasRenderingContext2D, props: DecodeFrameProps) => draw(context, props, colorMap, peakStyling), [colorMap, peakStyling])
 }
 
 const TPADecodedPositionLayer: FunctionComponent<DecodeLayerProps> = (props: DecodeLayerProps) => {

--- a/src/views/TrackPositionAnimation/TPADecodedPositionLogic.tsx
+++ b/src/views/TrackPositionAnimation/TPADecodedPositionLogic.tsx
@@ -78,11 +78,15 @@ export const useProbabilityFrames = (decodedData: DecodedPositionData | undefine
 }
 
 export const getDecodedPositionFramePx = (linearFrame: DecodedPositionFrame | undefined, decodedLocationsMap: DecodedProbabilityLocationsMap): DecodedPositionFramePx | undefined => {
-    const pixelLocations = linearFrame ? linearFrame.linearLocations.map((l) => decodedLocationsMap[l]) : []
+    if (linearFrame === undefined) return undefined
+    const sortedGroup = linearFrame.values.map((v, i) => {return {value: v, linearLocation: linearFrame.linearLocations[i]}}).sort((a, b) => (b.value - a.value)) // desc sort
+    const pixelLocations = sortedGroup.map(r => decodedLocationsMap[r.linearLocation])
+    const values = sortedGroup.map(r => r.value)
+    // const pixelLocations = linearFrame ? linearFrame.linearLocations.map((l) => decodedLocationsMap[l]) : []
     const finalFrame = linearFrame
         ? {
             locationRectsPx: pixelLocations,
-            values: linearFrame.values
+            values: values
         }
         : undefined
     return finalFrame

--- a/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
+++ b/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
@@ -7,7 +7,7 @@ import AnimationStateReducer, { AnimationState, AnimationStateAction, makeDefaul
 import useLiveTimeSyncing from 'views/common/Animation/AnimationUtilities/useTimeSyncing'
 import useTimeWindowSyncing from 'views/common/Animation/AnimationUtilities/useTimeWindowSyncing'
 import FrameAnimation from 'views/common/Animation/FrameAnimation'
-import TPADecodedPositionLayer, { useConfiguredPositionDrawFunction } from './TPADecodedPositionLayer'
+import TPADecodedPositionLayer, { useConfiguredDecodedPositionDrawFunction } from './TPADecodedPositionLayer'
 import { getDecodedPositionFramePx, useProbabilityFrames, useProbabilityLocationsMap } from './TPADecodedPositionLogic'
 import TPAPositionLayer from './TPAPositionLayer'
 import TPATrackLayer from './TPATrackLayer'
@@ -159,8 +159,12 @@ const TrackPositionAnimationView: FunctionComponent<TrackPositionAnimationProps>
     const currentProbabilityFrame = useMemo(() => {
         const linearFrame = animationState.frameData[animationState.currentFrameIndex]?.decodedPositionFrame
         const finalFrame = getDecodedPositionFramePx(linearFrame, decodedLocationsMap)
+        // The position frames are now sorted in descending order of value, so the first entry is always a valid max value.
+        const peakBinRect = finalFrame?.locationRectsPx[0] ?? undefined
+        const peakCenter = peakBinRect === undefined ? undefined : [peakBinRect[0] + (peakBinRect[2]/2), peakBinRect[1] + (peakBinRect[3]/2)]
         return {
-            frame: finalFrame
+            frame: finalFrame,
+            peakCenterPx: peakCenter
         }
     }, [animationState.currentFrameIndex, animationState.frameData, decodedLocationsMap])
 
@@ -176,14 +180,14 @@ const TrackPositionAnimationView: FunctionComponent<TrackPositionAnimationProps>
             height={drawHeight}
             trackBucketRectanglesPx={trackBins}
         />, [width, drawHeight, trackBins])
-        
-    const configuredPositionDrawFn = useConfiguredPositionDrawFunction('plasma')
+
+    const configuredDecodedPositionDrawFn = useConfiguredDecodedPositionDrawFunction('plasma')
     const probabilityLayer = useMemo(() => <TPADecodedPositionLayer
             width={width}
             height={drawHeight}
             drawData={currentProbabilityFrame}
-            configuredDrawFnCallback={configuredPositionDrawFn}
-        />, [width, drawHeight, currentProbabilityFrame, configuredPositionDrawFn])
+            configuredDrawFnCallback={configuredDecodedPositionDrawFn}
+        />, [width, drawHeight, currentProbabilityFrame, configuredDecodedPositionDrawFn])
 
     const positionLayer = useMemo(() => <TPAPositionLayer
             width={width}


### PR DESCRIPTION
Fixes #65.

Changes are fairly minimal--I've updated the `TPADecodedPositionLayer` to have an additional draw function for the "peak dot" (a dot in the center of a track bin with the highest probability value) with associated styling, configured through callback (it's just using default for now). Styling includes the ability to suppress display of this peak dot, if desired. (This could be made configurable by the data, but for now the styling settings are hard-coded, like all the others.)

To support the extra data, I'm calling out where the peak dot should be placed as part of the per-frame data for a decoded position frame. To find the location, we are now sorting the incoming bins by value before converting them to pixelspace (in `TPADecodedPositionLogic.getDecodedPositionFramePx`). This seemed somewhat less hacky than looking for the peak while iterating over the bins in the draw function, and also can kind of be justified by the idea that it would allow us to combine all drawing at a given intensity level into one `context.fill()` command in the future if we wanted to.

I did a spot check and things look to be correct: compare
https://www.figurl.org/f?v=gs://figurl/spikesortingview-8&d=sha1://2fd29200ff6ac8de2a312460f6dbf6a2cc3e4b5a&label=&s={}
vs
https://www.figurl.org/f?v=gs://figurl/spikesortingview-8devb&d=sha1://2fd29200ff6ac8de2a312460f6dbf6a2cc3e4b5a&label=&s={}
