### PR TITLE
66 fix head orientation

### DIFF
--- a/src/views/TrackPositionAnimation/TPAPositionLayer.tsx
+++ b/src/views/TrackPositionAnimation/TPAPositionLayer.tsx
@@ -25,6 +25,7 @@ const draw = (context: CanvasRenderingContext2D, props: PositionProps) => {
     const { bottomMargin, frame, dotStyle } = props
     if (!frame) return
 
+    console.log(`Head orientation: ${frame.headDirection}`)
     context.font = `${Math.min(Math.floor(bottomMargin * .5), 30)}px sans-serif`
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
     context.beginPath()
@@ -34,11 +35,11 @@ const draw = (context: CanvasRenderingContext2D, props: PositionProps) => {
     if (frame.headDirection) {
         const localHeadDirection = frame.headDirection// + rightAngle
         const headX = frame.x + defaultHeadRadius * cos(localHeadDirection)
-        const headY = frame.y + defaultHeadRadius * sin(localHeadDirection)
+        const headY = frame.y - defaultHeadRadius * sin(localHeadDirection)
         const triAX = frame.x + defaultTrianglePartialRadius * cos(localHeadDirection + rightAngle)
-        const triAY = frame.y + defaultTrianglePartialRadius * sin(localHeadDirection + rightAngle)
+        const triAY = frame.y - defaultTrianglePartialRadius * sin(localHeadDirection + rightAngle)
         const triBX = frame.x + defaultTrianglePartialRadius * cos(localHeadDirection - rightAngle)
-        const triBY = frame.y + defaultTrianglePartialRadius * sin(localHeadDirection - rightAngle)
+        const triBY = frame.y - defaultTrianglePartialRadius * sin(localHeadDirection - rightAngle)
 
         context.beginPath()
         context.moveTo(headX, headY)

--- a/src/views/TrackPositionAnimation/TPAPositionLayer.tsx
+++ b/src/views/TrackPositionAnimation/TPAPositionLayer.tsx
@@ -25,7 +25,6 @@ const draw = (context: CanvasRenderingContext2D, props: PositionProps) => {
     const { bottomMargin, frame, dotStyle } = props
     if (!frame) return
 
-    console.log(`Head orientation: ${frame.headDirection}`)
     context.font = `${Math.min(Math.floor(bottomMargin * .5), 30)}px sans-serif`
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
     context.beginPath()
@@ -33,7 +32,9 @@ const draw = (context: CanvasRenderingContext2D, props: PositionProps) => {
     context.arc(frame.x, frame.y, defaultPositionRadius, 0, 2*Math.PI)
     context.fill()
     if (frame.headDirection) {
-        const localHeadDirection = frame.headDirection// + rightAngle
+        const localHeadDirection = frame.headDirection
+        // remember, in pixelspace the y axis is flipped so its positive direction is down, not up.
+        // so we should be subtracting, not adding, the sin values.
         const headX = frame.x + defaultHeadRadius * cos(localHeadDirection)
         const headY = frame.y - defaultHeadRadius * sin(localHeadDirection)
         const triAX = frame.x + defaultTrianglePartialRadius * cos(localHeadDirection + rightAngle)

--- a/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
+++ b/src/views/TrackPositionAnimation/TrackPositionAnimationView.tsx
@@ -12,7 +12,7 @@ import AnimationStateReducer, { AnimationState, AnimationStateAction, makeDefaul
 import useLiveTimeSyncing from 'views/common/Animation/AnimationUtilities/useTimeSyncing'
 import useTimeWindowSyncing from 'views/common/Animation/AnimationUtilities/useTimeWindowSyncing'
 import FrameAnimation, { AnimationOptionalFeatures } from 'views/common/Animation/FrameAnimation'
-import TPADecodedPositionLayer, { useConfiguredPositionDrawFunction } from './TPADecodedPositionLayer'
+import TPADecodedPositionLayer, { useConfiguredDecodedPositionDrawFunction } from './TPADecodedPositionLayer'
 import { getDecodedPositionFramePx, useProbabilityFrames, useProbabilityLocationsMap } from './TPADecodedPositionLogic'
 import TPAPositionLayer from './TPAPositionLayer'
 import TPATrackLayer from './TPATrackLayer'


### PR DESCRIPTION
Fixes #66.

Note that, as described there, we could also have flipped the sign of the head orientation value, but I think the current version is more transparent.

(This PR also includes #79.)