### PR TITLE
Decouples playback control logic from UI.

### DIFF
--- a/src/views/common/Animation/AnimationControls/PlaybackChangeDirectionButton.tsx
+++ b/src/views/common/Animation/AnimationControls/PlaybackChangeDirectionButton.tsx
@@ -1,26 +1,17 @@
 import { faStepBackward, faStepForward } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import '../AnimationControlButtonStyles.css'
-import { ControlFeatures } from '../AnimationPlaybackControls'
-import { AnimationStateDispatcher } from '../AnimationStateReducer'
+import { PlaybackButtonLogicCallback } from './PlaybackControlButtonLogic'
 
 export type PlaybackChangeDirectionButtonProps = {
-    dispatch: AnimationStateDispatcher<any>
+    reverseDirectionHandler: PlaybackButtonLogicCallback
     playbackRate: number
-    ui?: ControlFeatures
 }
 
 
 const PlaybackChangeDirectionButton = (props: PlaybackChangeDirectionButtonProps) => {
-    const { dispatch, playbackRate } = props
-
-    const changeDirectionHandler = useCallback((e: React.MouseEvent) => {
-        dispatch({
-            type: 'SET_REPLAY_RATE',
-            newRate: -1 * playbackRate
-        })
-    }, [dispatch, playbackRate])
+    const { reverseDirectionHandler, playbackRate } = props
 
     // Alternatively, consider the faArrowRightArrowLeft icon, which wouldn't need to be changed and might be more expressive.
     const directionIcon = useMemo(() => {
@@ -29,11 +20,11 @@ const PlaybackChangeDirectionButton = (props: PlaybackChangeDirectionButtonProps
 
     const button = useMemo(() => {
         return (
-            <span onMouseDown={changeDirectionHandler} title="Reverse playback direction">
+            <span onMouseDown={reverseDirectionHandler} title="Reverse playback direction">
                 {directionIcon}
             </span>
         )
-    }, [changeDirectionHandler, directionIcon])
+    }, [reverseDirectionHandler, directionIcon])
 
     return button
 }

--- a/src/views/common/Animation/AnimationControls/PlaybackControlButtonLogic.ts
+++ b/src/views/common/Animation/AnimationControls/PlaybackControlButtonLogic.ts
@@ -1,0 +1,80 @@
+import React, { useCallback, useMemo } from "react"
+import { AnimationStateDispatcher } from "../AnimationStateReducer"
+
+export type PlaybackButtonLogicCallback = (e: React.MouseEvent<any> | React.KeyboardEvent<HTMLDivElement>) => void
+export type KeyHandler = (e: React.KeyboardEvent<HTMLDivElement>) => void
+
+export type PlaybackControlLogic = {
+    returnToBeginningHandler: PlaybackButtonLogicCallback
+    backSkipHandler: PlaybackButtonLogicCallback
+    forwardSkipHandler: PlaybackButtonLogicCallback
+    jumpToEndHandler: PlaybackButtonLogicCallback
+    playPauseHandler: PlaybackButtonLogicCallback
+    reverseDirectionHandler: PlaybackButtonLogicCallback
+    syncWindowHandler: PlaybackButtonLogicCallback
+    cropWindowHandler: PlaybackButtonLogicCallback
+    keyboardControlHandler: KeyHandler
+}
+
+const usePlaybackControlButtonLogic = (dispatch: AnimationStateDispatcher<any>): PlaybackControlLogic => {
+    const handleSkipArrow = useCallback((mode: 'end' | 'skip', backward?: boolean) => {
+        return (e: React.MouseEvent | React.KeyboardEvent) => {
+            dispatch({
+                type: mode === 'end' ? 'TO_END' : 'SKIP',
+                backward: backward
+            })
+        }
+    }, [dispatch])
+
+    const returnToBeginningHandler = useMemo(() => handleSkipArrow('end', true), [handleSkipArrow])
+    const backSkipHandler = useMemo(() => handleSkipArrow('skip', true), [handleSkipArrow])
+    const forwardSkipHandler = useMemo(() => handleSkipArrow('skip'), [handleSkipArrow])
+    const jumpToEndHandler = useMemo(() => handleSkipArrow('end'), [handleSkipArrow])
+
+    const playPauseHandler = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
+        dispatch({type: 'TOGGLE_PLAYBACK'})
+    }, [dispatch])
+
+    const reverseDirectionHandler = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
+        dispatch({type: 'REVERSE_REPLAY_RATE'})
+    }, [dispatch])
+
+    const syncWindowHandler = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
+        dispatch({type: 'TOGGLE_WINDOW_SYNC'})
+    }, [dispatch])
+
+    const cropWindowHandler = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
+        dispatch({type: 'COMMIT_WINDOW'})
+    }, [dispatch])
+
+    const fineAdjustmentHandler = useCallback((e: React.KeyboardEvent) => {
+        // This may be ill-advised
+        if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+        dispatch({
+            type: 'SKIP',
+            backward: e.key === 'ArrowLeft',
+            fineSteps: 1,
+            frameByFrame: e.ctrlKey
+        })
+    }, [dispatch])
+
+    const keyboardControlHandler = useCallback((e: React.KeyboardEvent) => {
+        switch(e.key) {
+            case 'ArrowLeft':
+            case 'ArrowRight':
+                fineAdjustmentHandler(e)
+                break
+            case ' ':
+                playPauseHandler(e)
+                break
+            default:
+                return
+        }
+    }, [fineAdjustmentHandler, playPauseHandler])
+
+    return { returnToBeginningHandler, backSkipHandler, forwardSkipHandler, jumpToEndHandler,
+            playPauseHandler, reverseDirectionHandler, syncWindowHandler, cropWindowHandler,
+            keyboardControlHandler }
+}
+
+export default usePlaybackControlButtonLogic

--- a/src/views/common/Animation/AnimationControls/PlaybackCropWindowButton.tsx
+++ b/src/views/common/Animation/AnimationControls/PlaybackCropWindowButton.tsx
@@ -1,23 +1,20 @@
 import { faArrowsLeftRightToLine } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { useCallback, useMemo } from 'react'
-import { AnimationStateDispatcher } from 'views/common/Animation/AnimationStateReducer'
+import { useMemo } from 'react'
+import { PlaybackButtonLogicCallback } from './PlaybackControlButtonLogic'
 
 
 export const CROP_BUTTON = "cropButton"
 
 type PlaybackCropWindowButtonProps = {
-    dispatch: AnimationStateDispatcher<any>
+    cropWindowHandler: PlaybackButtonLogicCallback
     isSynced: boolean
     isCropped: boolean
     willCrop: boolean
 }
 
 const PlaybackCropWindowButton = (props: PlaybackCropWindowButtonProps) => {
-    const { dispatch, isSynced, isCropped, willCrop } = props
-    const cropHandler = useCallback((E: React.MouseEvent) => {
-        dispatch({ type: 'COMMIT_WINDOW' })
-    }, [dispatch])
+    const { cropWindowHandler, isSynced, isCropped, willCrop } = props
 
     const cropButton = useMemo(() =>
         <span className={isSynced ? 'Inactive' : isCropped ? 'Highlighted' : ''}
@@ -28,12 +25,12 @@ const PlaybackCropWindowButton = (props: PlaybackCropWindowButtonProps) => {
                     : isCropped
                         ? "Show complete animation duration in playback bar"
                         : "Drag-click in the playback bar to select a focus range" }
-            onMouseDown={cropHandler}
+            onMouseDown={cropWindowHandler}
           >
             <FontAwesomeIcon icon={faArrowsLeftRightToLine} />
             {/* <FontAwesomeIcon icon={faCrop} /> */}
           </span>
-    , [isSynced, isCropped, willCrop, cropHandler])
+    , [isSynced, isCropped, willCrop, cropWindowHandler])
 
     return cropButton
 }

--- a/src/views/common/Animation/AnimationControls/PlaybackPlayPauseButton.tsx
+++ b/src/views/common/Animation/AnimationControls/PlaybackPlayPauseButton.tsx
@@ -18,7 +18,7 @@ const PlaybackPlayPauseButton = (props: PlaybackPlayPauseButtonProps) => {
 
     const button = useMemo(() => {
         return (
-            <span onMouseDown={playPauseHandler} title="Play/pause">
+            <span onMouseDown={playPauseHandler} title="Play/pause (space bar)">
                 {playPauseIcon}
             </span>
         )

--- a/src/views/common/Animation/AnimationControls/PlaybackPlayPauseButton.tsx
+++ b/src/views/common/Animation/AnimationControls/PlaybackPlayPauseButton.tsx
@@ -1,23 +1,16 @@
 import { faPause, faPlay } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import '../AnimationControlButtonStyles.css'
-import { AnimationStateDispatcher } from '../AnimationStateReducer'
+import { PlaybackButtonLogicCallback } from './PlaybackControlButtonLogic'
 
 type PlaybackPlayPauseButtonProps = {
-    dispatch: AnimationStateDispatcher<any>
+    playPauseHandler: PlaybackButtonLogicCallback
     isPlaying: boolean
 }
 
-
 const PlaybackPlayPauseButton = (props: PlaybackPlayPauseButtonProps) => {
-    const { dispatch, isPlaying } = props
-
-    const handlePlayPauseClick = useCallback((e: React.MouseEvent) => {
-        dispatch({
-            type: 'TOGGLE_PLAYBACK'
-        })
-    }, [dispatch])
+    const { playPauseHandler, isPlaying } = props
 
     const playPauseIcon = useMemo(() => {
         return isPlaying ? <FontAwesomeIcon icon={faPause} /> : <FontAwesomeIcon icon={faPlay} />
@@ -25,11 +18,11 @@ const PlaybackPlayPauseButton = (props: PlaybackPlayPauseButtonProps) => {
 
     const button = useMemo(() => {
         return (
-            <span onMouseDown={handlePlayPauseClick} title="Play/pause">
+            <span onMouseDown={playPauseHandler} title="Play/pause">
                 {playPauseIcon}
             </span>
         )
-    }, [handlePlayPauseClick, playPauseIcon])
+    }, [playPauseHandler, playPauseIcon])
 
     return button
 }

--- a/src/views/common/Animation/AnimationControls/PlaybackPositionArrowButtons.tsx
+++ b/src/views/common/Animation/AnimationControls/PlaybackPositionArrowButtons.tsx
@@ -1,37 +1,29 @@
 import { faBackward, faFastBackward, faFastForward, faForward } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { useCallback, useMemo } from 'react'
-import { AnimationStateDispatcher } from '../AnimationStateReducer'
+import { useMemo } from 'react'
+import { PlaybackControlLogic } from './PlaybackControlButtonLogic'
 
-const usePlaybackPositionArrowButtons = (dispatch: AnimationStateDispatcher<any>) => {
-    const handleArrowClick = useCallback((mode: 'end' | 'skip', backward?: boolean) => {
-        return (e: React.MouseEvent) => {
-            dispatch({
-                type: mode === 'end' ? 'TO_END' : 'SKIP',
-                backward: backward
-            })
-        }
-    }, [dispatch])
-
+const usePlaybackPositionArrowButtons = (logic: PlaybackControlLogic) => {
+    const {returnToBeginningHandler, backSkipHandler, forwardSkipHandler, jumpToEndHandler} = logic
     const beginningButton = useMemo(() => 
-        <span onMouseDown={handleArrowClick('end', true)} title="Return to beginning">
+        <span onMouseDown={returnToBeginningHandler} title="Return to beginning">
             <FontAwesomeIcon icon={faFastBackward} />
-        </span>, [handleArrowClick])
+        </span>, [returnToBeginningHandler])
 
     const backSkipButton = useMemo(() => 
-        <span onMouseDown={handleArrowClick('skip', true)} title="Return to beginning">
+        <span onMouseDown={backSkipHandler} title="Return to beginning">
             <FontAwesomeIcon icon={faBackward} />
-        </span>, [handleArrowClick])
+        </span>, [backSkipHandler])
 
     const forwardSkipButton = useMemo(() => 
-        <span onMouseDown={handleArrowClick('skip')} title="Skip forward">
+        <span onMouseDown={forwardSkipHandler} title="Skip forward">
             <FontAwesomeIcon icon={faForward} />
-        </span>, [handleArrowClick])
+        </span>, [forwardSkipHandler])
 
     const endButton = useMemo(() => 
-        <span onMouseDown={handleArrowClick('end')} title="Skip to end">
+        <span onMouseDown={jumpToEndHandler} title="Skip to end">
             <FontAwesomeIcon icon={faFastForward} />
-        </span>, [handleArrowClick])
+        </span>, [jumpToEndHandler])
 
 
     return { beginningButton, backSkipButton, forwardSkipButton, endButton }

--- a/src/views/common/Animation/AnimationControls/PlaybackSyncWindowButton.tsx
+++ b/src/views/common/Animation/AnimationControls/PlaybackSyncWindowButton.tsx
@@ -1,32 +1,28 @@
 import { faLink, faLinkSlash } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import React, { useCallback, useMemo } from 'react'
-import { AnimationStateDispatcher } from 'views/common/Animation/AnimationStateReducer'
+import { useMemo } from 'react'
+import { PlaybackButtonLogicCallback } from './PlaybackControlButtonLogic'
 
 
 export const SYNC_BUTTON = "syncButton"
 
 type PlaybackSyncButtonProps = {
-    dispatch: AnimationStateDispatcher<any>
+    syncWindowHandler: PlaybackButtonLogicCallback
     isSynced: boolean
 }
 
 const PlaybackSyncWindowButton = (props: PlaybackSyncButtonProps) => {
-    const { dispatch, isSynced } = props
-
-    const toggleWindowSyncHandler = useCallback((e: React.MouseEvent) => {
-        dispatch({ type: 'TOGGLE_WINDOW_SYNC' })
-    }, [dispatch])
+    const { syncWindowHandler, isSynced } = props
 
     const syncButton = useMemo(() => 
-        <span onMouseDown={toggleWindowSyncHandler}
+        <span onMouseDown={syncWindowHandler}
           title={isSynced
             ? "Unsync playback bar from global time range"
             : "Sync playback bar to global time range"}
         >
             {isSynced ? <FontAwesomeIcon icon={faLink} /> : <FontAwesomeIcon icon={faLinkSlash} />}
         </span>
-        , [isSynced, toggleWindowSyncHandler])
+        , [isSynced, syncWindowHandler])
 
     return syncButton
 }

--- a/src/views/common/Animation/AnimationPlaybackControls.tsx
+++ b/src/views/common/Animation/AnimationPlaybackControls.tsx
@@ -33,7 +33,7 @@ export type ControlFeatures = {
 }
 
 // TODO: Allow changing?
-const leftButtonWidthPx = 280  
+const leftButtonWidthPx = 280
 export type SelectionWindow = [number, number] | undefined
 export type SelectedWindowUpdater = React.Dispatch<React.SetStateAction<SelectionWindow>>
 

--- a/src/views/common/Animation/AnimationPlaybackControls.tsx
+++ b/src/views/common/Animation/AnimationPlaybackControls.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
+import { PlaybackControlLogic } from './AnimationControls/PlaybackControlButtonLogic'
 import { PlaybackOptionalButtons } from './AnimationControls/PlaybackOptionalButtons'
 import AnimationStatePlaybackBarLayer from './AnimationStatePlaybackBarLayer'
 import { AnimationStateDispatcher } from './AnimationStateReducer'
@@ -16,6 +17,7 @@ export type AnimationPlaybackControlsProps = {
     currentFrameIndex: number
     isPlaying: boolean
     playbackRate: number
+    logic: PlaybackControlLogic,
     ui?: ControlFeatures
 }
 
@@ -31,13 +33,13 @@ export type ControlFeatures = {
 }
 
 // TODO: Allow changing?
-const leftButtonWidthPx = 280
+const leftButtonWidthPx = 280  
 export type SelectionWindow = [number, number] | undefined
 export type SelectedWindowUpdater = React.Dispatch<React.SetStateAction<SelectionWindow>>
 
 
 const AnimationPlaybackControls = (props: AnimationPlaybackControlsProps) => {
-    const { width, height, verticalOffset, dispatch, isPlaying, visibleWindow, windowProposal, currentFrameIndex, playbackRate, ui } = props
+    const { width, height, verticalOffset, dispatch, isPlaying, visibleWindow, windowProposal, currentFrameIndex, playbackRate, logic, ui } = props
     const [selectedWindow, updateSelectedWindow] = useState<SelectionWindow>(undefined)
     useEffect(() => { updateSelectedWindow(undefined) }, [windowProposal])
 
@@ -48,11 +50,13 @@ const AnimationPlaybackControls = (props: AnimationPlaybackControlsProps) => {
             isPlaying={isPlaying}
             buttonWidthPx={leftButtonWidthPx}
             playbackRate={playbackRate}
+            logic={logic}
             ui={ui}
         />)
-    }, [height, dispatch, isPlaying, playbackRate, ui])
+    }, [height, dispatch, isPlaying, playbackRate, logic, ui])
 
-    const { panelWidth: secondaryControlPanelWidthPx, panel: secondaryPlaybackControlPanel } = GetSecondaryPlaybackControls({...props})
+    const secondaryControls = GetSecondaryPlaybackControls({...props})
+    const { panelWidth: secondaryControlPanelWidthPx, panel: secondaryPlaybackControlPanel } = secondaryControls
 
     const barLayerDiv = useMemo(() => {
         return (<AnimationStatePlaybackBarLayer

--- a/src/views/common/Animation/AnimationStateReducer.tsx
+++ b/src/views/common/Animation/AnimationStateReducer.tsx
@@ -21,7 +21,8 @@ export type AnimationState<T> = {
 
 export type AnimationStateDispatcher<T> = React.Dispatch<AnimationStateAction<T>>
 
-export type AnimationStateActionType = 'SET_DISPATCH' | 'UPDATE_FRAME_DATA' | 'SET_BASE_MS_PER_FRAME' | 'SET_REPLAY_RATE' | 
+export type AnimationStateActionType = 'SET_DISPATCH' | 'UPDATE_FRAME_DATA' | 'SET_BASE_MS_PER_FRAME' |
+                                       'SET_REPLAY_RATE' | 'REVERSE_REPLAY_RATE' |
                                        'SET_WINDOW' | 'PROPOSE_WINDOW' | 'COMMIT_WINDOW' | 'RELEASE_WINDOW' | 'TOGGLE_WINDOW_SYNC' |
                                        'TICK' |
                                        'TOGGLE_PLAYBACK' | 'SET_CURRENT_FRAME' | 'SKIP' | 'TO_END'
@@ -31,6 +32,7 @@ export type AnimationStateAction<T> =
     AnimationStateUpdateFrameDataAction<T> |
     AnimationStateSetBaseMsPerFrameAction |
     AnimationStateSetReplayRateAction |
+    AnimationStateReverseReplayRateAction |
     AnimationStateSetWindowAction |
     AnimationStateProposeWindowAction |
     AnimationStateCommitWindowAction |
@@ -61,6 +63,10 @@ export type AnimationStateSetBaseMsPerFrameAction = {
 export type AnimationStateSetReplayRateAction = {
     type: 'SET_REPLAY_RATE',
     newRate: number
+}
+
+export type AnimationStateReverseReplayRateAction = {
+    type: 'REVERSE_REPLAY_RATE'
 }
 
 export type AnimationStateSetWindowAction = {
@@ -123,6 +129,7 @@ export const TOGGLE_PLAYBACK: AnimationStateActionType = 'TOGGLE_PLAYBACK'
 export const SET_CURRENT_FRAME: AnimationStateActionType = 'SET_CURRENT_FRAME'
 export const SET_BASE_MS_PER_FRAME: AnimationStateActionType = 'SET_BASE_MS_PER_FRAME'
 export const SET_REPLAY_RATE: AnimationStateActionType = 'SET_REPLAY_RATE'
+export const REVERSE_REPLAY_RATE: AnimationStateActionType = 'REVERSE_REPLAY_RATE'
 export const SKIP: AnimationStateActionType = 'SKIP'
 export const TO_END: AnimationStateActionType = 'TO_END'
 
@@ -181,6 +188,8 @@ const AnimationStateReducer = <T, >(s: AnimationState<T>, a: AnimationStateActio
             }
             // refreshAnimationCycle(s)
             return { ...s, replayMultiplier: a.newRate, playbackStartedTimestamp: undefined }
+        case REVERSE_REPLAY_RATE:
+            return { ...s, replayMultiplier: -1 * s.replayMultiplier, playbackStartedTimestamp: undefined }
         case SET_WINDOW:
             return setWindow(s, a)
         case PROPOSE_WINDOW:

--- a/src/views/common/Animation/FrameAnimation.tsx
+++ b/src/views/common/Animation/FrameAnimation.tsx
@@ -96,11 +96,13 @@ const FrameAnimation: FunctionComponent<PropsWithChildren<FrameAnimationProps<an
             ui: uiFeatures
         }
     }, [width, controlsHeight, drawHeight, dispatch, state.frameData.length, state.window,
-        state.windowProposal, state.currentFrameIndex, state.isPlaying, uiFeatures, state.replayMultiplier])
+        state.windowProposal, state.currentFrameIndex, state.isPlaying, controlButtonLogic,
+        uiFeatures, state.replayMultiplier])
 
     const controlLayer = useMemo(() => <AnimationPlaybackControls {...animationControlProps} />, [animationControlProps])
     const handleKey = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
         controlButtonLogic.keyboardControlHandler(e)
+        // eslint-disable-next-line
     }, [controlButtonLogic.keyboardControlHandler])
     
     return (

--- a/src/views/common/Animation/MainPlaybackControls.tsx
+++ b/src/views/common/Animation/MainPlaybackControls.tsx
@@ -1,6 +1,7 @@
 import AnimationControlButtonContainer from './AnimationControlButtonContainer'
 import './AnimationControlButtonStyles.css'
 import PlaybackChangeDirectionButton from './AnimationControls/PlaybackChangeDirectionButton'
+import { PlaybackControlLogic } from './AnimationControls/PlaybackControlButtonLogic'
 import PlaybackPlayPauseButton from './AnimationControls/PlaybackPlayPauseButton'
 import usePlaybackPositionArrowButtons from './AnimationControls/PlaybackPositionArrowButtons'
 import PlaybackRateButtons from './AnimationControls/PlaybackRateButtons'
@@ -14,21 +15,22 @@ export type AnimationStateControlButtonsProps = {
     isPlaying: boolean
     buttonWidthPx: number
     playbackRate: number
+    logic: PlaybackControlLogic
     ui?: ControlFeatures
 }
 
 
 const MainPlaybackControls = (props: AnimationStateControlButtonsProps) => {
-    const { height, dispatch, buttonWidthPx, ui } = props
+    const { height, logic, buttonWidthPx, ui, isPlaying, playbackRate } = props
 
     const rateDropdown = <PlaybackRateDropdown {...props} />
     const rateButtons = <PlaybackRateButtons {...props} />
     const rateControl = ui?.usingRateButtons ? rateButtons : rateDropdown
 
-    const playPauseButton = <PlaybackPlayPauseButton {...props} />
-    const changeDirectionButton = <PlaybackChangeDirectionButton {...props} />
+    const playPauseButton = <PlaybackPlayPauseButton playPauseHandler={logic.playPauseHandler} isPlaying={isPlaying} />
+    const changeDirectionButton = <PlaybackChangeDirectionButton reverseDirectionHandler={logic.reverseDirectionHandler} playbackRate={playbackRate} />
 
-    const { beginningButton, endButton, forwardSkipButton, backSkipButton } = usePlaybackPositionArrowButtons(dispatch)
+    const { beginningButton, endButton, forwardSkipButton, backSkipButton } = usePlaybackPositionArrowButtons(logic)
 
     return (
         // Note, this one doesn't need to be squeezed when the dropdown is displayed, b/c that affects the layout

--- a/src/views/common/Animation/SecondaryPlaybackControls.tsx
+++ b/src/views/common/Animation/SecondaryPlaybackControls.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react'
 import AnimationControlButtonContainer from './AnimationControlButtonContainer'
 import PlaybackBookmarkButton, { BOOKMARK_BUTTON } from './AnimationControls/PlaybackBookmarkButton'
+import { PlaybackControlLogic } from './AnimationControls/PlaybackControlButtonLogic'
 import PlaybackCropWindowButton, { CROP_BUTTON } from './AnimationControls/PlaybackCropWindowButton'
 import PlaybackSyncWindowButton, { SYNC_BUTTON } from './AnimationControls/PlaybackSyncWindowButton'
 import { ControlFeatures } from './AnimationPlaybackControls'
-import { AnimationStateDispatcher } from './AnimationStateReducer'
 
 
 const perButtonRightButtonSpacingPx = 35
@@ -12,12 +12,12 @@ const perButtonRightButtonSpacingPx = 35
 type SecondaryControlButtonsProps = {
     width: number
     height: number
-    dispatch: AnimationStateDispatcher<any>
+    logic: PlaybackControlLogic
     ui?: ControlFeatures
 }
 
 const GetSecondaryPlaybackControls = (props: SecondaryControlButtonsProps) => {
-    const { width, height, dispatch, ui } = props
+    const { width, height, logic, ui } = props
 
     const rightButtonCount = useMemo(() => {
         return (ui?.optionalButtons?.length || 0)
@@ -26,9 +26,9 @@ const GetSecondaryPlaybackControls = (props: SecondaryControlButtonsProps) => {
 
     const selectedButtons = useMemo(() => new Set(ui?.optionalButtons), [ui?.optionalButtons])
     // TODO: Consider if this could result in building expensive buttons that aren't actually used.
-    const syncButton = PlaybackSyncWindowButton({dispatch, isSynced: (ui?.isSynced ?? false)})
+    const syncButton = PlaybackSyncWindowButton({syncWindowHandler: logic.syncWindowHandler, isSynced: (ui?.isSynced ?? false)})
     const cropButton = PlaybackCropWindowButton({
-        dispatch,
+        cropWindowHandler: logic.cropWindowHandler,
         isSynced: (ui?.isSynced ?? false),
         isCropped: (ui?.isCropped ?? false),
         willCrop: (ui?.couldCrop ?? false)

--- a/src/views/common/ViewToolbar.tsx
+++ b/src/views/common/ViewToolbar.tsx
@@ -39,7 +39,8 @@ const ToolbarButton: FunctionComponent<ToolbarElement> = (props: ToolbarElement)
                 key={props.elementIndex}
                 color={color}
                 style={iconButtonStyle}
-                disabled={props.disabled ? true : false}>
+                disabled={props.disabled ? true : false}
+            >
                 {props.icon}
             </IconButton>
         </span>


### PR DESCRIPTION
Previously, the state interaction for each button was coded in the same file with the component itself. This makes it difficult to provide alternate paths to trigger the effect of a button (such as by keypress).

This PR collects the button effects into a logic file and expresses them as a series of handlers that take either a `MouseEvent` or a `KeyboardEvent`. The handlers depend only on the animation state reducer, so they should update infrequently. Action logic can then be injected into the various UI components, making them lighter-weight as a result. But most importantly, the state-changing logic is now available at the level of the `FrameAnimation` component. This allows attaching the keypress handlers to the largest possible structural element (the entire animation widget) instead of to individual buttons, which would lead to problems with focus.

Addresses issue #64.