### PR TITLE
Fixes a missed memoization for 2d matrix transform.

### DIFF
--- a/src/views/LivePositionPdfPlot/LivePositionPdfPlotView.tsx
+++ b/src/views/LivePositionPdfPlot/LivePositionPdfPlotView.tsx
@@ -1,5 +1,5 @@
 import { runCalculationTaskAsync } from 'figurl'
-import React, { FunctionComponent, useMemo } from 'react'
+import { FunctionComponent, useMemo } from 'react'
 import { TimeseriesLayoutOpts } from 'View'
 import PositionPdfPlotWidget, { FetchSegmentQuery } from 'views/PositionPdfPlot/PositionPdfPlotWidget'
 import { LivePositionPdfPlotViewData } from './LivePositionPdfPlotViewData'

--- a/src/views/PositionPdfPlot/PositionPdfPlotView.tsx
+++ b/src/views/PositionPdfPlot/PositionPdfPlotView.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useMemo } from 'react'
+import { FunctionComponent, useMemo } from 'react'
 import { TimeseriesLayoutOpts } from 'View'
 import { PositionPdfPlotViewData } from './PositionPdfPlotViewData'
 import PositionPdfPlotWidget, { FetchSegmentQuery } from './PositionPdfPlotWidget'

--- a/src/views/PositionPdfPlot/PositionPdfPlotWidget.tsx
+++ b/src/views/PositionPdfPlot/PositionPdfPlotWidget.tsx
@@ -1,7 +1,6 @@
 import { Checkbox } from '@material-ui/core'
 import { useRecordingSelectionTimeInitialization, useTimeRange } from 'contexts/RecordingSelectionContext'
 import { FunctionComponent, useCallback, useMemo, useState } from 'react'
-import { convert1dDataSeries, use1dScalingMatrix } from 'util/pointProjection'
 import { TimeseriesLayoutOpts } from 'View'
 import TimeScrollView, { TimeScrollViewPanel } from 'views/common/TimeScrollView/TimeScrollView'
 import { usePanelDimensions, useTimeseriesMargins } from 'views/common/TimeScrollView/TimeScrollViewDimensions'
@@ -30,12 +29,20 @@ type Props = {
 }
 
 type PanelProps = {
+    offscreenCanvas?: HTMLCanvasElement
 }
 
 const panelSpacing = 4
 
-const usePositionPdfDataModel = (fetchSegment: (q: FetchSegmentQuery) => Promise<number[][]>, numTimepoints: number, numPositions: number, segmentSize: number, multiscaleFactor: number) => {
+const usePositionPdfDataModel = (fetchSegment: (q: FetchSegmentQuery) => Promise<number[][]>, numPositions: number, segmentSize: number) => {
     const fetchSegmentCache = useFetchCache<FetchSegmentQuery, number[][]>(fetchSegment)
+    // The fetch cache cannot be memoized, because the 'get' depends on the state.
+    // Thus it is updated every time the cache updates, including asynchronously.
+    // Alternative: consider reworking this hook to A) be able to answer subset queries without
+    // triggering a new query (e.g. if we have range (60, 120), we can return range (60, 100) at
+    // the same downsample level without a new query) and B) using a callback to populate the
+    // data rather than returning a function that returns the data (so that there won't be a need
+    // to use a lookup-function update as the trigger for a rerender/data refresh).
     const get = useCallback((i1: number, i2: number, downsampleFactor: number) => {
         const s1 = Math.floor(i1 / segmentSize)
         const s2 = Math.ceil(i2 / segmentSize)
@@ -55,13 +62,7 @@ const usePositionPdfDataModel = (fetchSegment: (q: FetchSegmentQuery) => Promise
         }
         return ret
     }, [fetchSegmentCache, numPositions, segmentSize])
-    return {
-        get,
-        numTimepoints,
-        numPositions,
-        segmentSize,
-        multiscaleFactor
-    }
+    return { get }
 }
 
 const emptyPanelSelection = new Set<number | string>()
@@ -70,55 +71,43 @@ const PositionPdfPlotWidget: FunctionComponent<Props> = ({fetchSegment, startTim
     useRecordingSelectionTimeInitialization(startTimeSec, endTimeSec)
     const { visibleTimeStartSeconds, visibleTimeEndSeconds } = useTimeRange()
     const numTimepoints = Math.floor((endTimeSec - startTimeSec) * samplingFrequency)
-    const dataModel = usePositionPdfDataModel(fetchSegment, numTimepoints, numPositions, segmentSize, multiscaleFactor)
+    const dataModel = usePositionPdfDataModel(fetchSegment, numPositions, segmentSize)
     const [showLinearPositionsOverlay, setShowLinearPositionsOverlay] = useState<boolean>(false)
+    
+    const rangeStartSample = useMemo(() => {
+        return visibleTimeStartSeconds === undefined ? 0 : Math.max(0, Math.floor(visibleTimeStartSeconds - startTimeSec) * samplingFrequency)
+    }, [visibleTimeStartSeconds, startTimeSec, samplingFrequency])
+    const rangeEndSample = useMemo(() => {
+        return visibleTimeEndSeconds === undefined ? 0 : Math.min(numTimepoints, Math.ceil((visibleTimeEndSeconds - startTimeSec) * samplingFrequency))
+    }, [visibleTimeEndSeconds, numTimepoints, startTimeSec, samplingFrequency])
 
-    const {downsampleFactor, i1, i2} = useMemo(() => {
-        if (visibleTimeStartSeconds === undefined) return {downsampleFactor: 1, i1: 0, i2: 0}
-        if (visibleTimeEndSeconds === undefined) return {downsampleFactor: 1, i1: 0, i2: 0}
-        const i1 = Math.max(0, Math.floor((visibleTimeStartSeconds - startTimeSec) * samplingFrequency))
-        const i2 = Math.min(dataModel.numTimepoints, Math.ceil((visibleTimeEndSeconds - startTimeSec) * samplingFrequency))
-        let downsampleFactor: number = 1
-        while ((i2 - i1) / (downsampleFactor * dataModel.multiscaleFactor) > width) {
-            downsampleFactor *= dataModel.multiscaleFactor
-        }
-        return {downsampleFactor, i1, i2}
-    }, [dataModel, samplingFrequency, startTimeSec, visibleTimeStartSeconds, visibleTimeEndSeconds, width])
+    const downsampleFactor = useMemo(() => {
+        if (visibleTimeStartSeconds === undefined || visibleTimeEndSeconds === undefined) return 1
+        const target = (rangeEndSample - rangeStartSample)/width
+        const factor = Math.ceil(Math.log(target)/Math.log(multiscaleFactor))
+        return Math.pow(multiscaleFactor, factor)
+    }, [visibleTimeStartSeconds, visibleTimeEndSeconds, rangeEndSample, rangeStartSample, width, multiscaleFactor])
 
-    const {visibleValues, t1, t2} = useMemo(() => {
-        if (visibleTimeStartSeconds === undefined) return {visibleValues: undefined, t1: 0, t2: 0}
-        if (visibleTimeEndSeconds === undefined) return {visibleValues: undefined, t1: 0, t2: 0}
-        
-        if (i2 <= i1) return {visibleValues: undefined, t1: 0, t2: 0}
-        
-        const j1 = Math.floor(i1 / downsampleFactor)
-        const j2 = Math.ceil(i2 / downsampleFactor)
+    const visibleValues = useMemo(() => {
+        if (visibleTimeStartSeconds === undefined) return undefined
+        if (visibleTimeEndSeconds === undefined) return undefined
+        if (rangeEndSample <= rangeStartSample) return undefined
+
+        const j1 = Math.floor(rangeStartSample / downsampleFactor)
+        const j2 = Math.ceil(rangeEndSample / downsampleFactor)
         const visibleValues = dataModel.get(j1, j2, downsampleFactor)
-        const t1 = startTimeSec + j1 * downsampleFactor / samplingFrequency
-        const t2 = startTimeSec + j2 * downsampleFactor / samplingFrequency
-        return {visibleValues, t1, t2}
-    }, [dataModel, visibleTimeStartSeconds, visibleTimeEndSeconds, startTimeSec, samplingFrequency, downsampleFactor, i1, i2])
-
+        return visibleValues
+    }, [dataModel, visibleTimeStartSeconds, visibleTimeEndSeconds, downsampleFactor, rangeStartSample, rangeEndSample])
+    
     const visibleLinearPositions: number[] | undefined = useMemo(() => {
         if (!linearPositions) return undefined
         if (visibleTimeStartSeconds === undefined) return undefined
         if (visibleTimeEndSeconds === undefined) return undefined
         const i1 = Math.max(0, Math.floor((visibleTimeStartSeconds - startTimeSec) * samplingFrequency))
-        const i2 = Math.min(dataModel.numTimepoints, Math.ceil((visibleTimeEndSeconds - startTimeSec) * samplingFrequency))
+        const i2 = Math.min(numTimepoints, Math.ceil((visibleTimeEndSeconds - startTimeSec) * samplingFrequency))
         return linearPositions.slice(i1, i2)
-    }, [dataModel.numTimepoints, linearPositions, samplingFrequency, startTimeSec, visibleTimeStartSeconds, visibleTimeEndSeconds])
-
-    const margins = useTimeseriesMargins(timeseriesLayoutOpts)
-
-    const panelCount = 1
-    const toolbarWidth = timeseriesLayoutOpts?.hideToolbar ? 0 : DefaultToolbarWidth
-    const { panelWidth, panelHeight } = usePanelDimensions(width - toolbarWidth, height, panelCount, panelSpacing, margins)
-    const timeToPixelMatrix = use1dScalingMatrix(panelWidth, visibleTimeStartSeconds, visibleTimeEndSeconds, margins.left)
-
-    const pixelTimes = useMemo(() => {
-        return convert1dDataSeries([t1, t2], timeToPixelMatrix)
-    }, [t1, t2, timeToPixelMatrix])
-
+    }, [numTimepoints, linearPositions, samplingFrequency, startTimeSec, visibleTimeStartSeconds, visibleTimeEndSeconds])
+    
     const {minValue, maxValue} = useMemo(() => {
         if (!visibleValues) return {minValue: 0, maxValue: 0}
         return {
@@ -126,47 +115,54 @@ const PositionPdfPlotWidget: FunctionComponent<Props> = ({fetchSegment, startTim
             maxValue: max(visibleValues.map(a => (max(a)))),
         }
     }, [visibleValues])
-
+    
     const imageData = useMemo(() => {
         if (!visibleValues) return undefined
         if (minValue === undefined) return undefined
         if (maxValue === undefined) return undefined
-        const N1 = visibleValues.length
-        const N2 = visibleValues[0].length
-        const imageData = new ImageData(N1, N2)
-        let i = 0
-        for (let i2=0; i2<N2; i2++) {
-            for (let i1=0; i1<N1; i1++) {
-                const vv = visibleValues[i1][N2 - 1 - i2]
-                if (vv !== undefined) {
-                    const v = (vv - minValue) / (maxValue - minValue)
-                    const col = colorForValue(v)
-                    imageData.data[i + 0] = col[0]
-                    imageData.data[i + 1] = col[1]
-                    imageData.data[i + 2] = col[2]
-                    imageData.data[i + 3] = 255
-                }
-                else {
-                    imageData.data[i + 0] = 0
-                    imageData.data[i + 1] = 0
-                    imageData.data[i + 2] = 0
-                    imageData.data[i + 3] = 0
-                }
-                i += 4
+        const totalTimePoints = visibleValues.length
+        const totalLinearPositionBuckets = visibleValues[0].length
+        const data = []
+        const colorForValue = getColorForValueFn(minValue, maxValue)
+        // We need to do a non-obvious transpose on the input data, because the input
+        // is structured as [timeCode][linearPositionBucket] -- i.e. the left-most array index
+        // describes the time point, which should be the x-axis on the visualization.
+        // Unfortunately, this corresponds to a column-major order, while our graphics need
+        // to be described as a one-dimensional array in row-major order (i.e. subsequent entries
+        // move across rows from left to right), and we also need to invert the y-axis. So
+        // we do a manual double loop here instead of just a flatmap().
+        for (let positionIndex = totalLinearPositionBuckets - 1; positionIndex >= 0; positionIndex--) {
+            for (let timeIndex = 0; timeIndex < totalTimePoints; timeIndex++) {
+                const value = visibleValues[timeIndex][positionIndex]
+                data.push(colorForValue(value))
             }
         }
+        const clampedData = Uint8ClampedArray.from(data.flat())
+        const imageData = new ImageData(clampedData, totalTimePoints)
         return imageData
     }, [visibleValues, minValue, maxValue])
+    
+    const margins = useTimeseriesMargins(timeseriesLayoutOpts)
+    const adjustedHeight = linearPositions ? height - 50 : height // leave an additional margin for the checkbox if we have linear positions to display
+    const panelCount = 1
+    const toolbarWidth = timeseriesLayoutOpts?.hideToolbar ? 0 : DefaultToolbarWidth
+    const { panelWidth, panelHeight } = usePanelDimensions(width - toolbarWidth, adjustedHeight, panelCount, panelSpacing, margins)
+    
+    const canvas = useMemo(() => {
+        return document.createElement('canvas')
+    }, [])
 
     const paintPanel = useCallback((context: CanvasRenderingContext2D, props: PanelProps) => {
+        const canvas = props.offscreenCanvas
+        if (canvas === undefined) return
         if (!imageData) return
-        // Draw scaled version of image
-        // See: https://stackoverflow.com/questions/3448347/how-to-scale-an-imagedata-in-html-canvas
-        const canvas = document.createElement('canvas')
+        if (canvas === undefined)  return
         canvas.width = imageData.width
         canvas.height = imageData.height
         const c = canvas.getContext('2d')
         if (!c) return
+        
+        c.clearRect(0, 0, canvas.width, canvas.height)
         c.putImageData(imageData, 0, 0)
         if ((showLinearPositionsOverlay) && (visibleLinearPositions)) {
             c.fillStyle = 'white'
@@ -177,22 +173,23 @@ const PositionPdfPlotWidget: FunctionComponent<Props> = ({fetchSegment, startTim
                 c.fillRect(xx - 0.5, yy + 0.5, 1, 1)
             }
         }
-        context.save()
-        context.scale((pixelTimes[1] - pixelTimes[0]) / imageData.width, panelHeight / imageData.height)
-        context.drawImage(canvas, pixelTimes[0], 0)
-        context.restore()
-    }, [pixelTimes, panelHeight, imageData, visibleLinearPositions, showLinearPositionsOverlay, downsampleFactor])
+        // Draw scaled version of image
+        // See: https://stackoverflow.com/questions/3448347/how-to-scale-an-imagedata-in-html-canvas
+
+        // Scaling the offscreen canvas can be done when it's drawn in, which avoids having to deal with transforms and some margin issues.
+        context.clearRect(0, 0, context.canvas.width, context.canvas.height)
+        context.drawImage(canvas, 0, 0, panelWidth, panelHeight)
+    }, [imageData, showLinearPositionsOverlay, visibleLinearPositions, downsampleFactor, panelWidth, panelHeight])
 
     const panels: TimeScrollViewPanel<PanelProps>[] = useMemo(() => {
         return [{
             key: `pdf`,
             label: ``,
-            props: {} as PanelProps,
+            props: {offscreenCanvas: canvas} as PanelProps,
             paint: paintPanel
         }]
-    }, [paintPanel])
+    }, [paintPanel, canvas])
     
-    const height2 = linearPositions ? height - 50 : height
     return (
         <div>
             <TimeScrollView
@@ -202,7 +199,7 @@ const PositionPdfPlotWidget: FunctionComponent<Props> = ({fetchSegment, startTim
                 selectedPanelKeys={emptyPanelSelection}
                 timeseriesLayoutOpts={timeseriesLayoutOpts}
                 width={width}
-                height={height2}
+                height={adjustedHeight}
             />
             {
                 linearPositions && (
@@ -230,9 +227,23 @@ export const allocate1d = (N: number, value: number | undefined) => {
     return ret
 }
 
-const colorForValue = (v: number) => {
-    const a = Math.max(0, Math.min(255, Math.floor(v * 255) * 3))
-    return [a, a, 60]
+/**
+ * Given a range of values, generates a function that maps a (possibly undefined)
+ * value in that range into an RGBA color value whose R and G intensities are
+ * in (0, 255) and proportional to the value's position within the range.
+ * The generated function returns black transparent pixels for undefined values.
+ * @param min Lowest value in the data range.
+ * @param max Highest value in the data range.
+ * @returns Convenience function to convert values to proportionally colored pixels.
+ */
+const getColorForValueFn = (min: number, max: number) => {
+    const theScale = 255 / (max - min)
+    return (v: number | undefined) => {
+        if (v === undefined) return [0, 0, 0, 0]
+        const proportion = (v - min) * theScale
+        const intensity = Math.max(0, Math.min(255, 3 * Math.floor(proportion)))
+        return [intensity, intensity, 60, 255]
+    }
 }
 
 const min = (a: (number | undefined)[]) => {

--- a/src/views/PositionPdfPlot/useFetchCache.ts
+++ b/src/views/PositionPdfPlot/useFetchCache.ts
@@ -1,5 +1,5 @@
 import objectHash from 'object-hash'
-import { useEffect, useMemo, useReducer, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react"
 
 export type FetchCache<QueryType, ReturnType> = {
     get: (query: QueryType) => ReturnType | undefined
@@ -65,11 +65,11 @@ const fetchCacheReducer = (state: FetchCacheState, action: FetchCacheAction): Fe
     }
 }
 
-const queryHash = <QueryType>(query: QueryType) => {
+const queryHash = <QueryType extends {} | null>(query: QueryType) => {
     return objectHash(query)
 }
 
-const useFetchCache = <QueryType, ReturnType>(fetchFunction: (query: QueryType) => Promise<any>): FetchCache<QueryType, ReturnType> => {
+const useFetchCache = <QueryType extends {} | null, ReturnType>(fetchFunction: (query: QueryType) => Promise<any>): FetchCache<QueryType, ReturnType> => {
     const [count, setCount] = useState(0)
     if (count < 0) console.info(count) // just suppress the unused warning (will never print)
     const prevFetchFunction = useRef<(query: QueryType) => Promise<any>>(fetchFunction)
@@ -82,7 +82,10 @@ const useFetchCache = <QueryType, ReturnType>(fetchFunction: (query: QueryType) 
             dispatch({type: 'clear'})
         }
     }, [fetchFunction])
-    const get = useMemo(() => ((query: QueryType) => {
+    // The `get` function depends on the state, so it updates every time a reducer operation
+    // fires. This is intended: updating the `get` is how we trigger consumers that a fetch
+    // operation has completed and there's new data available in the cache.
+    const get = useCallback((query: QueryType) => {
         const h = queryHash(query)
         const v = state.data[h]
         if ((v === undefined) && (!state.activeFetches[h])) {
@@ -92,7 +95,7 @@ const useFetchCache = <QueryType, ReturnType>(fetchFunction: (query: QueryType) 
             }
         }
         return v
-    }), [state.data, state.activeFetches])
+    }, [state.data, state.activeFetches])
     const fetch = useMemo(() => ((query: QueryType) => {
         const h = queryHash(query)
         const val = state.data[h]

--- a/src/views/common/TimeScrollView/TSVCursorLayer.tsx
+++ b/src/views/common/TimeScrollView/TSVCursorLayer.tsx
@@ -1,5 +1,5 @@
 import BaseCanvas from 'FigurlCanvas/BaseCanvas';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 export type TSVCursorLayerProps = {
     timeRange: [number, number]

--- a/src/views/common/TimeScrollView/TimeScrollView.tsx
+++ b/src/views/common/TimeScrollView/TimeScrollView.tsx
@@ -1,6 +1,6 @@
 import { useTimeRange } from 'contexts/RecordingSelectionContext';
 import Splitter from 'MountainWorkspace/components/Splitter/Splitter';
-import { useEffect, useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { use1dScalingMatrix } from 'util/pointProjection';
 import { TimeseriesLayoutOpts } from 'View';
 import { TickSet } from 'views/common/TimeScrollView/YAxisTicks';
@@ -78,17 +78,16 @@ const TimeScrollView = <T extends {[key: string]: any}> (props: TimeScrollViewPr
 
     // TODO: It'd be nice to show some sort of visual indication of how much zoom has been requested,
 
-    const content = (
-        <div
-            style={{width: width - toolbarWidth, height, position: 'relative'}}
-            onWheel={handleWheel}
-            onMouseDown={handleMouseDown}
-            onMouseUp={handleMouseUp}
-            onMouseMove={handleMouseMove}
-            onMouseOut={handleMouseLeave}
-        >
+    const effectiveWidth = useMemo(() => width - toolbarWidth, [width, toolbarWidth])
+
+    const style = useMemo(() => {
+        return {width: effectiveWidth, height, position: 'relative'} as any as React.CSSProperties},
+        [effectiveWidth, height])
+
+    const axesLayer = useMemo(() => {
+        return (
             <TSVAxesLayer<T>
-                width={width - toolbarWidth}
+                width={effectiveWidth}
                 height={height}
                 panels={panels}
                 panelHeight={panelHeight}
@@ -98,32 +97,68 @@ const TimeScrollView = <T extends {[key: string]: any}> (props: TimeScrollViewPr
                 timeTicks={timeTicks}
                 yTickSet={yTickSet}
                 margins={definedMargins}
-                hideTimeAxis={hideTimeAxis}
-            />
+                hideTimeAxis={hideTimeAxis} 
+            />)
+    }, [effectiveWidth, height, panels, panelHeight, perPanelOffset, selectedPanelKeys,
+        timeRange, timeTicks, yTickSet, definedMargins, hideTimeAxis])
+
+    const mainLayer = useMemo(() => {
+        return (
             <TSVMainLayer<T>
-                width={width - toolbarWidth}
+                width={effectiveWidth}
                 height={height}
                 panels={panels}
                 panelHeight={panelHeight}
                 perPanelOffset={perPanelOffset}
                 margins={definedMargins}
             />
-            <TSVHighlightLayer
-                width={width - toolbarWidth}
-                height={height}
-                highlightSpans={pixelHighlightSpans}
-                margins={definedMargins}
-            />
+        )
+    }, [effectiveWidth, height, panels, panelHeight, perPanelOffset, definedMargins])
+
+    const highlightLayer = useMemo(() => {
+        return (
+            pixelHighlightSpans.length > 0
+            ? <TSVHighlightLayer
+                    width={effectiveWidth}
+                    height={height}
+                    highlightSpans={pixelHighlightSpans}
+                    margins={definedMargins}
+              />
+            : <div />
+        )
+    }, [effectiveWidth, height, pixelHighlightSpans, definedMargins])
+
+    const cursorLayer = useMemo(() => {
+        return (
             <TSVCursorLayer
-                width={width - toolbarWidth}
+                width={effectiveWidth}
                 height={height}
                 timeRange={timeRange}
                 margins={definedMargins}
                 focusTimePixels={focusTimeInPixels}
             />
-        </div>
-    )
+        )
+    }, [effectiveWidth, height, timeRange, definedMargins, focusTimeInPixels])
 
+    const content = useMemo(() => {
+        return (
+            <div
+                style={style}
+                onWheel={handleWheel}
+                onMouseDown={handleMouseDown}
+                onMouseUp={handleMouseUp}
+                onMouseMove={handleMouseMove}
+                onMouseOut={handleMouseLeave}
+            >
+                {axesLayer}
+                {mainLayer}
+                {highlightLayer}
+                {cursorLayer}
+            </div>
+        )
+    }, [style, handleWheel, handleMouseDown, handleMouseUp, handleMouseMove, handleMouseLeave,
+        axesLayer, mainLayer, highlightLayer, cursorLayer])
+    
     if (hideToolbar) {
         return (
             <div ref={divRef}>

--- a/src/views/common/TimeScrollView/TimeScrollViewDimensions.ts
+++ b/src/views/common/TimeScrollView/TimeScrollViewDimensions.ts
@@ -19,7 +19,7 @@ export type Margins = {
 }
 
 
-export const defaultMargins = {
+const defaultMargins: Margins = {
     left: 30,
     right: 20,
     top: 20,
@@ -63,8 +63,9 @@ export const usePanelDimensions = (width: number, height: number, panelCount: nu
 
 export const useFocusTimeInPixels = (timeToPixelMatrix: Matrix) => {
     const {focusTime} = useTimeFocus()
-    return useMemo(() => {
+    const pixelTime = useMemo(() => {
         if (focusTime === undefined) return undefined
         return convert1dDataSeries([focusTime], timeToPixelMatrix)[0]
     }, [timeToPixelMatrix, focusTime])
+    return pixelTime
 }

--- a/src/views/common/TimeScrollView/TimeScrollViewInteractions/TimeScrollViewEventHandlers.ts
+++ b/src/views/common/TimeScrollView/TimeScrollViewInteractions/TimeScrollViewEventHandlers.ts
@@ -1,5 +1,5 @@
 import { useTimeFocus, useTimeRange } from 'contexts/RecordingSelectionContext';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { clearDivFocus, divExists, setDivFocus } from './divRefHandling';
 import useTimeScrollPan, { PanUpdateProperties } from './useTimeScrollPan';
 
@@ -107,7 +107,11 @@ const useTimeScrollEventHandlers = (leftMargin: number, panelWidth: number, divR
     const handleMouseMove = useMouseMoveHandler(divRef, clickReader, startPan, setPanUpdate)
     const handleMouseLeave = useMouseLeaveHandler(divRef, clearPan)
 
-    return {handleMouseUp, handleMouseMove, handleMouseDown, handleMouseLeave}
+    const handlers = useMemo(() => {
+        return {handleMouseUp, handleMouseMove, handleMouseDown, handleMouseLeave}
+    }, [handleMouseUp, handleMouseMove, handleMouseDown, handleMouseLeave])
+
+    return handlers
 }
 
 export default useTimeScrollEventHandlers


### PR DESCRIPTION
The important part of this PR is correcting a missed memoization call in the point transforms library. Also important are some clarifying/simplifying changes and decoupling the `PositionPdfPlotWidget`.

I've left some notes for ways we could make the cache system more efficient, but that's well outside the scope of this task--if we want to pursue it, it should be a separate issue first with its own prioritization.