### PR TITLE
Put visibility logic in the useTimeFocus() hook.

### DIFF
--- a/src/libraries/component-time-scroll-view/TimeScrollViewDimensions.ts
+++ b/src/libraries/component-time-scroll-view/TimeScrollViewDimensions.ts
@@ -1,4 +1,4 @@
-import { useTimeFocus, useTimeRange } from 'libraries/context-recording-selection';
+import { useTimeFocus } from 'libraries/context-recording-selection';
 import { convert1dDataSeries } from 'libraries/util-point-projection';
 import { Matrix } from 'mathjs';
 import { useMemo } from 'react';
@@ -74,14 +74,11 @@ export const usePanelDimensions = (width: number, height: number, panelCount: nu
 }
 
 export const useFocusTimeInPixels = (timeToPixelMatrix: Matrix) => {
-    const {focusTime} = useTimeFocus()
-    const {visibleTimeStartSeconds, visibleTimeEndSeconds} = useTimeRange()
+    const {focusTime, focusTimeIsVisible} = useTimeFocus()
     const pixelTime = useMemo(() => {
-        if (focusTime === undefined) return undefined
-        if ((focusTime < (visibleTimeStartSeconds || 0)) || (focusTime > (visibleTimeEndSeconds || 0))) {
-            return undefined
-        }
-        return convert1dDataSeries([focusTime], timeToPixelMatrix)[0]
-    }, [timeToPixelMatrix, focusTime, visibleTimeStartSeconds, visibleTimeEndSeconds])
+        return (focusTime !== undefined && focusTimeIsVisible)
+            ? convert1dDataSeries([focusTime], timeToPixelMatrix)[0]
+            : undefined
+    }, [timeToPixelMatrix, focusTime, focusTimeIsVisible])
     return pixelTime
 }

--- a/src/libraries/context-recording-selection/RecordingSelectionContext.ts
+++ b/src/libraries/context-recording-selection/RecordingSelectionContext.ts
@@ -135,8 +135,12 @@ export const useTimeFocus = () => {
             focusTimeSec: timeForFraction(fraction)
         })
     }, [recordingSelectionDispatch, timeForFraction])
+    const focusTimeIsVisible = recordingSelection.focusTimeSeconds !== undefined
+                               && recordingSelection.focusTimeSeconds <= (recordingSelection.visibleTimeEndSeconds || 0)
+                               && recordingSelection.focusTimeSeconds >= (recordingSelection.visibleTimeStartSeconds || 0)
     return {
         focusTime: recordingSelection.focusTimeSeconds,
+        focusTimeIsVisible,
         setTimeFocus,
         setTimeFocusFraction,
         timeForFraction


### PR DESCRIPTION
I think we're better off having the logic for whether the focus is visible reside with the hook that defines it from the context, rather than in the display logic in TimeScrollView. This just makes that change.