### PR TITLE
timeseriesgraph legend

### DIFF
--- a/devel/deploy_legend_dev.sh
+++ b/devel/deploy_legend_dev.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+TARGET=gs://figurl/spikesortingview-9-legend-dev
+
+yarn build
+gsutil -m cp -R ./build/* $TARGET/

--- a/src/libraries/view-timeseries-graph/TimeseriesGraphView.tsx
+++ b/src/libraries/view-timeseries-graph/TimeseriesGraphView.tsx
@@ -79,6 +79,7 @@ const TimeseriesGraphView: FunctionComponent<Props> = ({data, timeseriesLayoutOp
         const entryFontSize = 12
         const symbolWidth = 50
         const legendWidth = 200
+        const margin = 10
         const legendHeight = 20 + seriesToInclude.length * entryHeight
         const R = location === 'northwest' ? {x: 20, y: 20, w: legendWidth, h: legendHeight} :
                   location === 'northeast' ? {x: panelWidth - legendWidth - 20, y: 20, w: legendWidth, h: legendHeight} : undefined
@@ -89,40 +90,37 @@ const TimeseriesGraphView: FunctionComponent<Props> = ({data, timeseriesLayoutOp
         context.fillRect(R.x, R.y, R.w, R.h)
         context.strokeRect(R.x, R.y, R.w, R.h)
 
-        for (let i = 0; i < seriesToInclude.length; i++) {
-            const y0 = R.y + 10 + i * entryHeight
-            const s = seriesToInclude[i]
-            if (s.title) {
-                const symbolRect = {x: R.x + 10, y: y0, w: symbolWidth, h: entryHeight}
-                const titleRect = {x: R.x + 10 + symbolWidth + 10, y: y0, w: legendWidth - 10 - 10 - symbolWidth - 10, h: entryHeight}
-                const title = s.title || 'untitled'
-                context.fillStyle = 'black'
-                context.font = `${entryFontSize}px Arial`
-                context.fillText(title, titleRect.x, titleRect.y + titleRect.h / 2 + entryFontSize / 2)
-                if (s.type === 'line') {
-                    applyLineAttributes(context, s.attributes)
+        seriesToInclude.forEach((s, i) => {
+            const y0 = R.y + margin + i * entryHeight
+            const symbolRect = {x: R.x + margin, y: y0, w: symbolWidth, h: entryHeight}
+            const titleRect = {x: R.x + margin + symbolWidth + margin, y: y0, w: legendWidth - margin - margin - symbolWidth - margin, h: entryHeight}
+            const title = s.title || 'untitled'
+            context.fillStyle = 'black'
+            context.font = `${entryFontSize}px Arial`
+            context.fillText(title, titleRect.x, titleRect.y + titleRect.h / 2 + entryFontSize / 2)
+            if (s.type === 'line') {
+                applyLineAttributes(context, s.attributes)
+                context.beginPath()
+                context.moveTo(symbolRect.x, symbolRect.y + symbolRect.h / 2)
+                context.lineTo(symbolRect.x + symbolRect.w, symbolRect.y + symbolRect.h / 2)
+                context.stroke()
+                context.setLineDash([])
+            }
+            else if (s.type === 'marker') {
+                applyMarkerAttributes(context, s.attributes)
+                const radius = entryHeight * 0.3
+                const shape = s.attributes['shape'] ?? 'circle'
+                const center = {x: symbolRect.x + symbolRect.w / 2, y: symbolRect.y + symbolRect.h / 2}
+                if (shape === 'circle') {
                     context.beginPath()
-                    context.moveTo(symbolRect.x, symbolRect.y + symbolRect.h / 2)
-                    context.lineTo(symbolRect.x + symbolRect.w, symbolRect.y + symbolRect.h / 2)
-                    context.stroke()
-                    context.setLineDash([])
+                    context.ellipse(center.x, center.y, radius, radius, 0, 0, 2 * Math.PI)
+                    context.fill()
                 }
-                else if (s.type === 'marker') {
-                    applyMarkerAttributes(context, s.attributes)
-                    const radius = entryHeight * 0.3
-                    const shape = s.attributes['shape'] ?? 'circle'
-                    const center = {x: symbolRect.x + symbolRect.w / 2, y: symbolRect.y + symbolRect.h / 2}
-                    if (shape === 'circle') {
-                        context.beginPath()
-                        context.ellipse(center.x, center.y, radius, radius, 0, 0, 2 * Math.PI)
-                        context.fill()
-                    }
-                    else if (shape === 'square') {
-                        context.fillRect(center.x - radius, center.y - radius, radius * 2, radius * 2)
-                    }
+                else if (shape === 'square') {
+                    context.fillRect(center.x - radius, center.y - radius, radius * 2, radius * 2)
                 }
             }
-        }
+        })
     }, [legendOpts, series, panelWidth])
 
     // We need to have the panelHeight before we can use it in the paint function.

--- a/src/libraries/view-timeseries-graph/TimeseriesGraphView.tsx
+++ b/src/libraries/view-timeseries-graph/TimeseriesGraphView.tsx
@@ -72,12 +72,14 @@ const TimeseriesGraphView: FunctionComponent<Props> = ({data, timeseriesLayoutOp
         if (!opts) {
             opts = {location: 'northeast'} // for testing
         }
+        const seriesToInclude = series.filter(s => (s.title))
+        if (seriesToInclude.length === 0) return
         const {location} = opts
         const entryHeight = 18
         const entryFontSize = 12
         const symbolWidth = 50
         const legendWidth = 200
-        const legendHeight = 20 + series.length * entryHeight
+        const legendHeight = 20 + seriesToInclude.length * entryHeight
         const R = location === 'northwest' ? {x: 20, y: 20, w: legendWidth, h: legendHeight} :
                   location === 'northeast' ? {x: panelWidth - legendWidth - 20, y: 20, w: legendWidth, h: legendHeight} : undefined
         if (!R) return //unexpected
@@ -87,9 +89,9 @@ const TimeseriesGraphView: FunctionComponent<Props> = ({data, timeseriesLayoutOp
         context.fillRect(R.x, R.y, R.w, R.h)
         context.strokeRect(R.x, R.y, R.w, R.h)
 
-        for (let i = 0; i < series.length; i++) {
+        for (let i = 0; i < seriesToInclude.length; i++) {
             const y0 = R.y + 10 + i * entryHeight
-            const s = series[i]
+            const s = seriesToInclude[i]
             if (s.title) {
                 const symbolRect = {x: R.x + 10, y: y0, w: symbolWidth, h: entryHeight}
                 const titleRect = {x: R.x + 10 + symbolWidth + 10, y: y0, w: legendWidth - 10 - 10 - symbolWidth - 10, h: entryHeight}

--- a/src/libraries/view-timeseries-graph/TimeseriesGraphView.tsx
+++ b/src/libraries/view-timeseries-graph/TimeseriesGraphView.tsx
@@ -73,8 +73,8 @@ const TimeseriesGraphView: FunctionComponent<Props> = ({data, timeseriesLayoutOp
             opts = {location: 'northeast'} // for testing
         }
         const {location} = opts
-        const entryHeight = 25
-        const entryFontSize = 14
+        const entryHeight = 18
+        const entryFontSize = 12
         const symbolWidth = 50
         const legendWidth = 200
         const legendHeight = 20 + series.length * entryHeight
@@ -90,33 +90,34 @@ const TimeseriesGraphView: FunctionComponent<Props> = ({data, timeseriesLayoutOp
         for (let i = 0; i < series.length; i++) {
             const y0 = R.y + 10 + i * entryHeight
             const s = series[i]
-            
-            const symbolRect = {x: R.x + 10, y: y0, w: symbolWidth, h: entryHeight}
-            const titleRect = {x: R.x + 10 + symbolWidth + 10, y: y0, w: legendWidth - 10 - 10 - symbolWidth - 10, h: entryHeight}
-            const title = s.title || 'untitled'
-            context.fillStyle = 'black'
-            context.font = `${entryFontSize}px Arial`
-            context.fillText(title, titleRect.x, titleRect.y + titleRect.h / 2 + entryFontSize / 2 - 2)
-            if (s.type === 'line') {
-                applyLineAttributes(context, s.attributes)
-                context.beginPath()
-                context.moveTo(symbolRect.x, symbolRect.y + symbolRect.h / 2)
-                context.lineTo(symbolRect.x + symbolRect.w, symbolRect.y + symbolRect.h / 2)
-                context.stroke()
-                context.setLineDash([])
-            }
-            else if (s.type === 'marker') {
-                applyMarkerAttributes(context, s.attributes)
-                const radius = entryHeight * 0.3
-                const shape = s.attributes['shape'] ?? 'circle'
-                const center = {x: symbolRect.x + symbolRect.w / 2, y: symbolRect.y + symbolRect.h / 2}
-                if (shape === 'circle') {
+            if (s.title) {
+                const symbolRect = {x: R.x + 10, y: y0, w: symbolWidth, h: entryHeight}
+                const titleRect = {x: R.x + 10 + symbolWidth + 10, y: y0, w: legendWidth - 10 - 10 - symbolWidth - 10, h: entryHeight}
+                const title = s.title || 'untitled'
+                context.fillStyle = 'black'
+                context.font = `${entryFontSize}px Arial`
+                context.fillText(title, titleRect.x, titleRect.y + titleRect.h / 2 + entryFontSize / 2)
+                if (s.type === 'line') {
+                    applyLineAttributes(context, s.attributes)
                     context.beginPath()
-                    context.ellipse(center.x, center.y, radius, radius, 0, 0, 2 * Math.PI)
-                    context.fill()
+                    context.moveTo(symbolRect.x, symbolRect.y + symbolRect.h / 2)
+                    context.lineTo(symbolRect.x + symbolRect.w, symbolRect.y + symbolRect.h / 2)
+                    context.stroke()
+                    context.setLineDash([])
                 }
-                else if (shape === 'square') {
-                    context.fillRect(center.x - radius, center.y - radius, radius * 2, radius * 2)
+                else if (s.type === 'marker') {
+                    applyMarkerAttributes(context, s.attributes)
+                    const radius = entryHeight * 0.3
+                    const shape = s.attributes['shape'] ?? 'circle'
+                    const center = {x: symbolRect.x + symbolRect.w / 2, y: symbolRect.y + symbolRect.h / 2}
+                    if (shape === 'circle') {
+                        context.beginPath()
+                        context.ellipse(center.x, center.y, radius, radius, 0, 0, 2 * Math.PI)
+                        context.fill()
+                    }
+                    else if (shape === 'square') {
+                        context.fillRect(center.x - radius, center.y - radius, radius * 2, radius * 2)
+                    }
                 }
             }
         }

--- a/src/libraries/view-timeseries-graph/TimeseriesGraphViewData.ts
+++ b/src/libraries/view-timeseries-graph/TimeseriesGraphViewData.ts
@@ -1,6 +1,9 @@
 import { isEqualTo, isNumber, optional, validateObject } from "libraries/util-validate-object"
 import { isString } from "mathjs"
 
+type LegendOpts = {
+    location: 'northwest' | 'northeast'
+}
 
 type Dataset = {
     name: string
@@ -10,6 +13,7 @@ type Dataset = {
 type Series = {
     type: string
     dataset: string
+    title?: string
     encoding: {[key: string]: any}
     attributes: {[key: string]: any}
 }
@@ -19,6 +23,7 @@ export type TimeseriesGraphViewData = {
     datasets: Dataset[],
     series: Series[]
     timeOffset?: number
+    legendOpts?: LegendOpts
 }
 
 export const isTimeseriesGraphViewData = (x: any): x is TimeseriesGraphViewData => {
@@ -32,8 +37,12 @@ export const isTimeseriesGraphViewData = (x: any): x is TimeseriesGraphViewData 
             type: isString,
             dataset: isString,
             encoding: () => (true),
-            attributes: () => (true)
+            attributes: () => (true),
+            title: optional(isString)
         })),
-        timeOffset: optional(isNumber)
+        timeOffset: optional(isNumber),
+        legendOpts: optional((y: any) => validateObject(y, {
+            location: isString
+        }))
     }, {allowAdditionalFields: true})
 }


### PR DESCRIPTION
Example:
https://www.figurl.org/f?v=gs://figurl/spikesortingview-9-legend-dev&d=sha1://0d9cb4bae0e34ccbf4d897cbd51fcb27efa0c471&label=Timeseries%20graph%20example

A new optional property in TimeseriesGraphViewData.
```
legendOpts: {location: 'northwest'} // also available: 'northeast
```
and on each individual series object, an optional `title` string

Legend is shown in upper left or upper right (depending on location) and includes one line for each series that has a title.

