### PR TITLE
focus time interval

### DIFF
--- a/src/libraries/component-time-scroll-view/TSVCursorLayer.tsx
+++ b/src/libraries/component-time-scroll-view/TSVCursorLayer.tsx
@@ -4,14 +4,21 @@ import React, { useMemo } from 'react';
 export type TSVCursorLayerProps = {
     timeRange: [number, number]
     focusTimePixels?: number
+    focusTimeIntervalPixels?: [number, number]
     margins: {left: number, right: number, top: number, bottom: number}
     width: number
     height: number
 }
 
 const paintCursor = (context: CanvasRenderingContext2D, props: TSVCursorLayerProps) => {
-    const {margins, focusTimePixels } = props
+    const {margins, focusTimePixels, focusTimeIntervalPixels } = props
     context.clearRect(0, 0, context.canvas.width, context.canvas.height)
+
+    // focus time interval
+    if (focusTimeIntervalPixels !== undefined) {
+        context.fillStyle = 'rgb(255, 225, 225)'
+        context.fillRect(focusTimeIntervalPixels[0], margins.top, focusTimeIntervalPixels[1] - focusTimeIntervalPixels[0], context.canvas.height - margins.bottom - margins.top)
+    }
 
     // focus time
     if (focusTimePixels !== undefined) {
@@ -24,10 +31,10 @@ const paintCursor = (context: CanvasRenderingContext2D, props: TSVCursorLayerPro
 }
 
 const TSVCursorLayer = (props: TSVCursorLayerProps) => {
-    const {width, height, timeRange, focusTimePixels, margins } = props
+    const {width, height, timeRange, focusTimePixels, focusTimeIntervalPixels, margins } = props
     const drawData = useMemo(() => ({
-        width, height, timeRange, focusTimePixels, margins
-    }), [width, height, timeRange, focusTimePixels, margins])
+        width, height, timeRange, focusTimePixels, focusTimeIntervalPixels, margins
+    }), [width, height, timeRange, focusTimePixels, focusTimeIntervalPixels, margins])
 
     return (
         <BaseCanvas

--- a/src/libraries/component-time-scroll-view/TSVCursorLayer.tsx
+++ b/src/libraries/component-time-scroll-view/TSVCursorLayer.tsx
@@ -16,12 +16,18 @@ const paintCursor = (context: CanvasRenderingContext2D, props: TSVCursorLayerPro
 
     // focus time interval
     if (focusTimeIntervalPixels !== undefined) {
-        context.fillStyle = 'rgb(255, 225, 225)'
-        context.fillRect(focusTimeIntervalPixels[0], margins.top, focusTimeIntervalPixels[1] - focusTimeIntervalPixels[0], context.canvas.height - margins.bottom - margins.top)
+        context.fillStyle = 'rgba(255, 225, 225, 0.4)'
+        context.strokeStyle = 'rgba(150, 50, 50, 0.9)'
+        const x = focusTimeIntervalPixels[0]
+        const y = margins.top
+        const w = focusTimeIntervalPixels[1] - focusTimeIntervalPixels[0]
+        const h = context.canvas.height - margins.bottom - margins.top
+        context.fillRect(x, y, w, h)
+        context.strokeRect(x, y, w, h)
     }
 
     // focus time
-    if (focusTimePixels !== undefined) {
+    if ((focusTimePixels !== undefined) && (focusTimeIntervalPixels === undefined)) {
         context.strokeStyle = 'red'
         context.beginPath()
         context.moveTo(focusTimePixels, margins.top)

--- a/src/libraries/component-time-scroll-view/TimeScrollView.tsx
+++ b/src/libraries/component-time-scroll-view/TimeScrollView.tsx
@@ -151,10 +151,10 @@ const TimeScrollView = <T extends {[key: string]: any}> (props: TimeScrollViewPr
                 onMouseMove={handleMouseMove}
                 onMouseOut={handleMouseLeave}
             >
-                {cursorLayer}
                 {axesLayer}
                 {mainLayer}
                 {highlightLayer}
+                {cursorLayer}
             </div>
         )
     }, [style, handleWheel, handleMouseDown, handleMouseUp, handleMouseMove, handleMouseLeave,

--- a/src/libraries/component-time-scroll-view/TimeScrollView.tsx
+++ b/src/libraries/component-time-scroll-view/TimeScrollView.tsx
@@ -65,7 +65,7 @@ const TimeScrollView = <T extends {[key: string]: any}> (props: TimeScrollViewPr
     const perPanelOffset = panelHeight + panelSpacing
 
     const timeToPixelMatrix = use1dScalingMatrix(panelWidth, visibleTimeStartSeconds, visibleTimeEndSeconds, definedMargins.left)
-    const focusTimeInPixels = useFocusTimeInPixels(timeToPixelMatrix)
+    const {focusTimeInPixels, focusTimeIntervalInPixels} = useFocusTimeInPixels(timeToPixelMatrix)
 
     const timeTicks = useTimeTicks(visibleTimeStartSeconds, visibleTimeEndSeconds, timeToPixelMatrix)
 
@@ -136,9 +136,10 @@ const TimeScrollView = <T extends {[key: string]: any}> (props: TimeScrollViewPr
                 timeRange={timeRange}
                 margins={definedMargins}
                 focusTimePixels={focusTimeInPixels}
+                focusTimeIntervalPixels={focusTimeIntervalInPixels}
             />
         )
-    }, [effectiveWidth, height, timeRange, definedMargins, focusTimeInPixels])
+    }, [effectiveWidth, height, timeRange, definedMargins, focusTimeInPixels, focusTimeIntervalInPixels])
 
     const content = useMemo(() => {
         return (
@@ -150,10 +151,10 @@ const TimeScrollView = <T extends {[key: string]: any}> (props: TimeScrollViewPr
                 onMouseMove={handleMouseMove}
                 onMouseOut={handleMouseLeave}
             >
+                {cursorLayer}
                 {axesLayer}
                 {mainLayer}
                 {highlightLayer}
-                {cursorLayer}
             </div>
         )
     }, [style, handleWheel, handleMouseDown, handleMouseUp, handleMouseMove, handleMouseLeave,

--- a/src/libraries/component-time-scroll-view/TimeScrollViewDimensions.ts
+++ b/src/libraries/component-time-scroll-view/TimeScrollViewDimensions.ts
@@ -74,10 +74,12 @@ export const usePanelDimensions = (width: number, height: number, panelCount: nu
 }
 
 export const useFocusTimeInPixels = (timeToPixelMatrix: Matrix) => {
-    const {focusTime} = useTimeFocus()
+    const {focusTime, focusTimeInterval} = useTimeFocus()
     const pixelTime = useMemo(() => {
-        if (focusTime === undefined) return undefined
-        return convert1dDataSeries([focusTime], timeToPixelMatrix)[0]
-    }, [timeToPixelMatrix, focusTime])
+        return {
+            focusTimeInPixels: focusTime !== undefined ? convert1dDataSeries([focusTime], timeToPixelMatrix)[0] : undefined,
+            focusTimeIntervalInPixels: focusTimeInterval !== undefined ? convert1dDataSeries(focusTimeInterval, timeToPixelMatrix) as [number, number] : undefined,
+        }
+    }, [timeToPixelMatrix, focusTime, focusTimeInterval])
     return pixelTime
 }

--- a/src/libraries/component-time-scroll-view/TimeScrollViewInteractions/TimeScrollViewEventHandlers.ts
+++ b/src/libraries/component-time-scroll-view/TimeScrollViewInteractions/TimeScrollViewEventHandlers.ts
@@ -54,11 +54,11 @@ const useMouseLeaveHandler = (divRef: DivRef, clearPanState: () => void) => {
 }
 
 
-const useClickHandler = (divRef: DivRef, clickReader: ClickReader, setTimeFocusFraction: (fraction: number) => void) => {
+const useClickHandler = (divRef: DivRef, clickReader: ClickReader, setTimeFocusFraction: (fraction: number, opts: {event: React.MouseEvent}) => void) => {
     const handler = useCallback((e: React.MouseEvent) => {
         if (divExists(divRef)) {
             const {fraction} = clickReader(e)
-            setTimeFocusFraction(fraction)
+            setTimeFocusFraction(fraction, {event: e})
             setDivFocus(divRef)
         }
     }, [clickReader, setTimeFocusFraction, divRef])

--- a/src/libraries/context-recording-selection/RecordingSelectionContext.ts
+++ b/src/libraries/context-recording-selection/RecordingSelectionContext.ts
@@ -355,7 +355,7 @@ const setFocusTime = (state: RecordingSelection, action: SetFocusTimeRecordingSe
         if (t0 !== undefined) {
             const t1 = Math.min(t0, focusTimeSec)
             const t2 = Math.max(t0, focusTimeSec)
-            newState = {...newState, focusTimeIntervalSeconds: [t1, t2]}
+            newState = {...newState, focusTimeSeconds: state.focusTimeSeconds, focusTimeIntervalSeconds: [t1, t2]}
         }
     }
     return selectionIsValid(newState) ? newState : state


### PR DESCRIPTION
Fixes #139 

This is pretty straightforward. Added a focusTimeIntervalSeconds to the recording selection state. Put in the appropriate handlers. Shift+click selects the time interval

https://www.figurl.org/f?v=http://localhost:3000&d=sha1://7719fce3538437c9e739692bef2f9d1cd0118b8f&label=Timeseries%20graph%20example&s={%22annotations%22:%22sha1://27df7514e64711fb21fec8bc781f10196f95bbf7%22}

![image](https://user-images.githubusercontent.com/3679296/190279728-2c74855d-5736-4056-ad5e-35d24976b290.png)
